### PR TITLE
Make dolt folder mountable

### DIFF
--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -23,7 +23,7 @@ jobs:
         image: chenditc/investment_data:latest
         options: -v ${{ github.workspace }}:/output
         run: |
-          bash -c "bash dump_qlib_bin.sh && cp ./qlib_bin.tar.gz /output/"
+          bash -c "bash dump_qlib_bin.sh -c && cp ./qlib_bin.tar.gz /output/"
     - name: Upload binaries to release
       uses: svenstaro/upload-release-action@v2
       with:

--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -23,7 +23,7 @@ jobs:
         image: chenditc/investment_data:latest
         options: -v ${{ github.workspace }}:/output
         run: |
-          bash -c "bash dump_qlib_bin.sh -c && cp ./qlib_bin.tar.gz /output/"
+          bash -c "bash dump_qlib_bin.sh && cp ./qlib_bin.tar.gz /output/"
     - name: Upload binaries to release
       uses: svenstaro/upload-release-action@v2
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM continuumio/anaconda3
+FROM continuumio/miniconda3
 
 RUN wget https://github.com/dolthub/dolt/releases/download/v0.75.12/dolt-linux-amd64.tar.gz -O /tmp/dolt-linux-amd64.tar.gz && cd /tmp && tar -zxvf /tmp/dolt-linux-amd64.tar.gz && cp /tmp/dolt-linux-amd64/bin/dolt /usr/bin/ && rm -rf /tmp/*
 RUN apt update && apt install -y git psmisc zip gcc g++
-RUN cd / && dolt clone chenditc/investment_data
+RUN mkdir -p /dolt
+RUN mkdir -p /investment_data
+
 RUN cd /investment_data && git init && git pull https://github.com/chenditc/investment_data.git
 RUN  pip install numpy && pip install --upgrade cython \
    && cd / && git clone https://github.com/microsoft/qlib.git \

--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ To download as dolt database:
 ```
 docker run 
   -v /<some output directory>:/output
-  -v /<dolt directory>:/dolt 
   -it --rm chenditc/investment_data bash dump_qlib_bin.sh && cp ./qlib_bin.tar.gz /output/
+```
+
+You can use the following parameter to mount an existing dolt chenditc/investment_data folder to the container.
+```
+  -v /<dolt directory>:/dolt 
 ```
 
 ## Run Daily Update

--- a/README.md
+++ b/README.md
@@ -5,22 +5,19 @@ Chinese blog about this project: [量化系列2 - 众包数据集](https://mp.we
 
 - [How to use it](#how-to-use-it)
 - [Developement Setup](#developement-setup)
-  * [Install dolt](#install-dolt)
-  * [Clone data](#clone-data)
-  * [Export to qlib format](#export-to-qlib-format)
-  * [Run Daily Update](#run-daily-update)
-  * [Daily update and output](#daily-update-and-output)
-  * [Extract tar file to qlib directory](#extract-tar-file-to-qlib-directory)
+  - [Install dolt](#install-dolt)
+  - [Clone data](#clone-data)
+  - [Export to qlib format](#export-to-qlib-format)
+  - [Run Daily Update](#run-daily-update)
+  - [Daily update and output](#daily-update-and-output)
+  - [Extract tar file to qlib directory](#extract-tar-file-to-qlib-directory)
 - [Initiative](#initiative)
 - [Project Detail](#project-detail)
-  * [Data Source](#data-source)
-  * [Initial import](#initial-import)
-  * [Daily Update](#daily-update)
-  * [Merge logic](#merge-logic)
-  * [Validation logic](#validation-logic)
+  - [Data Source](#data-source)
+  - [Initial loading and Validation logic for each table](#initial-loading-and-validation-logic-for-each-table)
 - [Contribution Guide](#contribution-guide)
-  * [Add more stock index](#add-more-stock-index)
-  * [Add more data source or fields](#Add-more-data-source-or-fields)
+  - [Add more stock index](#add-more-stock-index)
+  - [Add more data source or fields](#add-more-data-source-or-fields)
 
 <small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
 
@@ -48,7 +45,10 @@ To download as dolt database:
 
 ## Export to qlib format
 ```
-docker run -v /<some output directory>:/output -it --rm chenditc/investment_data bash dump_qlib_bin.sh && cp ./qlib_bin.tar.gz /output/
+docker run 
+  -v /<some output directory>:/output
+  -v /<dolt directory>:/dolt 
+  -it --rm chenditc/investment_data bash dump_qlib_bin.sh && cp ./qlib_bin.tar.gz /output/
 ```
 
 ## Run Daily Update

--- a/dump_qlib_bin.sh
+++ b/dump_qlib_bin.sh
@@ -1,9 +1,14 @@
 set -e
 set -x
-cd /investment_data/
+cd /dolt/investment_data
 dolt pull origin
 
 dolt sql-server &
+
+# wait for sql server start
+sleep 5s
+
+cd /investment_data
 mkdir ./qlib/qlib_source
 python3 ./qlib/dump_all_to_qlib_source.py
 

--- a/dump_qlib_bin.sh
+++ b/dump_qlib_bin.sh
@@ -1,17 +1,10 @@
 set -e
 set -x
 
-while getopts "c" opt
-do
-    case "$opt" in
-        c )
-        cd /dolt/
-        dolt clone chenditc/investment_data
-    ;;
-    esac
-done
+[ ! -d "/dolt/investment_data" ] && cd /dolt && dolt clone chenditc/investment_data
 
 cd /dolt/investment_data
+dolt pull origin
 dolt sql-server &
 
 # wait for sql server start

--- a/dump_qlib_bin.sh
+++ b/dump_qlib_bin.sh
@@ -1,8 +1,17 @@
 set -e
 set -x
-cd /dolt/investment_data
-dolt pull origin
 
+while getopts "c" opt
+do
+    case "$opt" in
+        c )
+        cd /dolt/
+        dolt clone chenditc/investment_data
+    ;;
+    esac
+done
+
+cd /dolt/investment_data
 dolt sql-server &
 
 # wait for sql server start


### PR DESCRIPTION
Pulling the dolt repo every time could be a waste of effort.

I'm proposing using a separate folder to manage the dolt database.

I assume that this will impact the workflow / github action for daily update, should we identify the actual requirement and find a decent solution?