### PR TITLE
[dump source] query all symbols in one batch, grouped dumps by symbol

### DIFF
--- a/qlib/dump_all_to_qlib_source.py
+++ b/qlib/dump_all_to_qlib_source.py
@@ -7,17 +7,18 @@ import os
 def dump_all_to_sqlib_source(skip_exists=True):
   sqlEngine = create_engine('mysql+pymysql://root:@127.0.0.1/investment_data', pool_recycle=3600)
   dbConnection = sqlEngine.connect()
-  universe = pd.read_sql("select symbol from final_a_stock_eod_price group by symbol", dbConnection)
+  stock_df = pd.read_sql("select *, amount/volume*10 as vwap from final_a_stock_eod_price", dbConnection)
+  dbConnection.close()
+  sqlEngine.dispose()
 
   script_path = os.path.dirname(os.path.realpath(__file__))
 
-  for symbol in universe["symbol"]:
+  for symbol, df in stock_df.groupby("symbol"):
     filename = f'{script_path}/qlib_source/{symbol}.csv'
     print("Dumping to file: ", filename)
     if skip_exists and os.path.isfile(filename):
         continue
-    stock_df = pd.read_sql(f"select *, amount/volume*10 as vwap from final_a_stock_eod_price where symbol='{symbol}'", dbConnection)
-    stock_df.to_csv(filename, index=False)
+    df.to_csv(filename, index=False)
 
 if __name__ == "__main__":
   fire.Fire(dump_all_to_sqlib_source)


### PR DESCRIPTION
### What is changed and why?

- Per profiling offline, the sql query's are time consuming. This MR makes the query's in one batch to save time.
- `DataFrame.groupby` is much faster than `df[df.foo == bar]` for many times.

### How is it tested and caveats.

- Tested offline, the scripts ran successfully with no error, the output csv files looks good.
- It takes ~150s to finish the script now on my machine (32g32c, 13900K).
- The peak mem usage is ~18g by simply observing with `htop`.