### PR TITLE
Add script for manual release upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ bash daily_update.sh
 docker run -v /<some output directory>:/output -it --rm chenditc/investment_data bash daily_update.sh && bash dump_qlib_bin.sh && cp ./qlib_bin.tar.gz /output/
 ```
 
+## Upload to GitHub release
+Generate the tarball and upload it to the repository's release page without GitHub Actions:
+
+```
+docker run --rm -e GITHUB_PAT=<token> chenditc/investment_data bash upload_release.sh
+```
+
 ## Extract tar file to qlib directory
 ```
 tar -zxvf qlib_bin.tar.gz -C ~/.qlib/qlib_data/cn_data --strip-components=1

--- a/docs/final_a_stock_eod_price.ch.md
+++ b/docs/final_a_stock_eod_price.ch.md
@@ -11,6 +11,7 @@
 目前，每日更新仅使用tushare数据源，并由github action触发。
 1. 我维护了一个离线任务，它每30分钟运行一次[daily_update.sh](daily_update.sh)以收集数据并推送到dolthub。
 2. 一个github action [.github/workflows/upload_release.yml](.github/workflows/upload_release.yml)每日触发，然后调用bash dump_qlib_bin.sh生成每日tar文件并上传到发布页面。
+   同样的流程也可以在容器内手动执行，运行[upload_release.sh](../upload_release.sh)并提供`GITHUB_PAT`环境变量即可将生成的tar文件上传到GitHub。
 
 ## 合并逻辑
 1. 使用w数据源作为基准，使用其他数据源进行验证。

--- a/docs/final_a_stock_eod_price.md
+++ b/docs/final_a_stock_eod_price.md
@@ -12,6 +12,7 @@
 Currently the daily update is only using tushare data source and triggered by github action.
 1. I maintained a offline job whcih runs [daily_update.sh](daily_update.sh) every 30 mins to collect data and push to dolthub.
 2. A github action [.github/workflows/upload_release.yml](.github/workflows/upload_release.yml) is triggered daily, which then calls bash dump_qlib_bin.sh to generate daily tar file and upload to release page.
+   The same process can be executed manually inside the container by running [upload_release.sh](../upload_release.sh), which expects a `GITHUB_PAT` environment variable and uploads the generated tarball to GitHub.
 
 ## Merge logic
 1. Use w data source as baseline, use other data source to validate against it.

--- a/upload_release.sh
+++ b/upload_release.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate qlib bin tarball and upload it as a GitHub release asset.
+# Requires a GitHub personal access token in $GITHUB_PAT (or $GH_TOKEN / $GITHUB_TOKEN).
+
+TOKEN="${GITHUB_PAT:-${GH_TOKEN:-${GITHUB_TOKEN:-}}}"
+if [[ -z "${TOKEN}" ]]; then
+  echo "Error: GITHUB_PAT environment variable is not set." >&2
+  exit 1
+fi
+
+# Determine repository (owner/repo)
+REPO="${GITHUB_REPOSITORY:-}" 
+if [[ -z "${REPO}" ]]; then
+  # Try to parse from git config
+  ORIGIN_URL=$(git config --get remote.origin.url)
+  REPO=$(echo "$ORIGIN_URL" | sed -n 's#.*github.com[/:]\(.*\)\.git#\1#p')
+fi
+if [[ -z "${REPO}" ]]; then
+  echo "Error: could not determine repository." >&2
+  exit 1
+fi
+
+DATE=$(date +%F)
+ASSET_NAME="qlib_bin.tar.gz"
+BODY="Daily update release"
+
+# Run dump script to generate the tarball
+bash dump_qlib_bin.sh
+
+FILE_PATH="$(pwd)/${ASSET_NAME}"
+if [[ ! -f "${FILE_PATH}" ]]; then
+  echo "Error: ${FILE_PATH} not found" >&2
+  exit 1
+fi
+
+API="https://api.github.com/repos/${REPO}"
+AUTH_HEADER="Authorization: token ${TOKEN}"
+
+# Get or create release
+RELEASE_ID=$(curl -fsSL -H "${AUTH_HEADER}" "${API}/releases/tags/${DATE}" | jq -r '.id' 2>/dev/null || true)
+if [[ -z "${RELEASE_ID}" || "${RELEASE_ID}" == "null" ]]; then
+  RELEASE_ID=$(curl -fsSL -H "${AUTH_HEADER}" -H 'Content-Type: application/json' \
+    -d "{\"tag_name\":\"${DATE}\",\"name\":\"${DATE}\",\"body\":\"${BODY}\"}" \
+    "${API}/releases" | jq -r '.id')
+fi
+
+if [[ -z "${RELEASE_ID}" || "${RELEASE_ID}" == "null" ]]; then
+  echo "Error: unable to create or fetch release." >&2
+  exit 1
+fi
+
+# Delete existing asset if present
+ASSET_ID=$(curl -fsSL -H "${AUTH_HEADER}" "${API}/releases/${RELEASE_ID}/assets" | jq -r \
+  ".[] | select(.name==\"${ASSET_NAME}\") | .id")
+if [[ -n "${ASSET_ID}" ]]; then
+  curl -fsSL -X DELETE -H "${AUTH_HEADER}" "${API}/releases/assets/${ASSET_ID}" >/dev/null
+fi
+
+# Upload new asset
+UPLOAD_URL=$(curl -fsSL -H "${AUTH_HEADER}" "${API}/releases/${RELEASE_ID}" | jq -r '.upload_url' | sed 's/{?name,label}//')
+
+curl -fsSL -H "${AUTH_HEADER}" -H "Content-Type: application/gzip" \
+  --data-binary "@${FILE_PATH}" "${UPLOAD_URL}?name=${ASSET_NAME}" >/dev/null
+
+echo "Uploaded ${ASSET_NAME} to release ${DATE}"


### PR DESCRIPTION
## Summary
- add `upload_release.sh` to generate qlib bin tarball and upload to GitHub release using a PAT
- document how to run `upload_release.sh` and link from release docs

## Testing
- `bash -n upload_release.sh`


------
https://chatgpt.com/codex/tasks/task_e_689ffa9ff4ec832aa592ace212e7bd8a