### PR TITLE
Fix release script path and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9
 
 RUN wget https://github.com/dolthub/dolt/releases/download/v1.30.4/dolt-linux-amd64.tar.gz -O /tmp/dolt-linux-amd64.tar.gz && cd /tmp && tar -zxvf /tmp/dolt-linux-amd64.tar.gz && cp /tmp/dolt-linux-amd64/bin/dolt /usr/bin/ && rm -rf /tmp/* && dolt config --global --add user.email "dockeruser@na.com" && dolt config --global --add user.name "dockeruser"
-RUN apt update && apt install -y git psmisc zip gcc g++
+RUN apt update && apt install -y git psmisc zip gcc g++ jq
 RUN mkdir -p /dolt
 RUN mkdir -p /investment_data
 

--- a/dump_qlib_bin.sh
+++ b/dump_qlib_bin.sh
@@ -1,6 +1,6 @@
 set -e
 set -x
-WORKING_DIR=${1} 
+WORKING_DIR=${1:-$(pwd)}
 QLIB_REPO=${2:-https://github.com/microsoft/qlib.git} 
 
 if ! command -v dolt &> /dev/null
@@ -37,8 +37,6 @@ cp qlib/qlib_index/csi* $WORKING_DIR/qlib_bin/instruments/
 
 tar -czvf ./qlib_bin.tar.gz $WORKING_DIR/qlib_bin/
 ls -lh ./qlib_bin.tar.gz
-if [ -d "/output" ]; then
-    mv ./qlib_bin.tar.gz /output/
-else
-    echo "Directory /output does not exist."
-fi
+mkdir -p /output
+mv ./qlib_bin.tar.gz /output/
+

--- a/upload_release.sh
+++ b/upload_release.sh
@@ -9,9 +9,13 @@ if [[ -z "${TOKEN}" ]]; then
   echo "Error: GITHUB_PAT environment variable is not set." >&2
   exit 1
 fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required but not installed." >&2
+  exit 1
+fi
 
 # Determine repository (owner/repo)
-REPO="${REPO:-${GITHUB_REPOSITORY:-chenidtc/investment_data}}"
+REPO="${REPO:-${GITHUB_REPOSITORY:-chenditc/investment_data}}"
 
 DATE=$(date +%F)
 ASSET_NAME="qlib_bin.tar.gz"
@@ -20,7 +24,7 @@ BODY="Daily update release"
 # Run dump script to generate the tarball
 bash dump_qlib_bin.sh
 
-FILE_PATH="")(pwd)/${ASSET_NAME}"
+FILE_PATH="$(pwd)/${ASSET_NAME}"
 if [[ ! -f "${FILE_PATH}" ]]; then
   echo "Error: ${FILE_PATH} not found" >&2
   exit 1


### PR DESCRIPTION
## Summary
- Ensure upload_release.sh checks for jq and correct repository
- Move generated tarball to /output and default working dir in dump_qlib_bin.sh
- Add jq to Dockerfile for release script

## Testing
- `bash -n upload_release.sh`
- `bash -n dump_qlib_bin.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a020751610832aabc3f16f71141847