### PR TITLE
Fix release upload script for container usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.9
 
 RUN wget https://github.com/dolthub/dolt/releases/download/v1.30.4/dolt-linux-amd64.tar.gz -O /tmp/dolt-linux-amd64.tar.gz && cd /tmp && tar -zxvf /tmp/dolt-linux-amd64.tar.gz && cp /tmp/dolt-linux-amd64/bin/dolt /usr/bin/ && rm -rf /tmp/* && dolt config --global --add user.email "dockeruser@na.com" && dolt config --global --add user.name "dockeruser"
-RUN apt update && apt install -y git psmisc zip gcc g++
+RUN apt update && apt install -y git psmisc zip gcc g++ jq
 RUN mkdir -p /dolt
-RUN mkdir -p /investment_data
+RUN mkdir -p /investment_data /output
 
 RUN cd /investment_data && git init && git pull https://github.com/chenditc/investment_data.git
 RUN  pip install numpy==1.23.5 && pip install --upgrade cython \

--- a/dump_qlib_bin.sh
+++ b/dump_qlib_bin.sh
@@ -37,8 +37,10 @@ cp qlib/qlib_index/csi* $WORKING_DIR/qlib_bin/instruments/
 
 tar -czvf ./qlib_bin.tar.gz $WORKING_DIR/qlib_bin/
 ls -lh ./qlib_bin.tar.gz
-if [ -d "/output" ]; then
-    mv ./qlib_bin.tar.gz /output/
+OUTPUT_DIR=${OUTPUT_DIR:-/output}
+if [ -d "${OUTPUT_DIR}" ]; then
+    mv ./qlib_bin.tar.gz "${OUTPUT_DIR}/"
+    ls -lh "${OUTPUT_DIR}/qlib_bin.tar.gz"
 else
-    echo "Directory /output does not exist."
+    echo "Generated tarball at $(pwd)/qlib_bin.tar.gz"
 fi

--- a/upload_release.sh
+++ b/upload_release.sh
@@ -17,10 +17,16 @@ DATE=$(date +%F)
 ASSET_NAME="qlib_bin.tar.gz"
 BODY="Daily update release"
 
-# Run dump script to generate the tarball
-bash dump_qlib_bin.sh
+# Ensure jq is available
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required but not installed." >&2
+  exit 1
+fi
 
-FILE_PATH="")(pwd)/${ASSET_NAME}"
+# Run dump script to generate the tarball
+bash dump_qlib_bin.sh "$(pwd)"
+
+FILE_PATH="$(pwd)/${ASSET_NAME}"
 if [[ ! -f "${FILE_PATH}" ]]; then
   echo "Error: ${FILE_PATH} not found" >&2
   exit 1
@@ -30,7 +36,7 @@ API="https://api.github.com/repos/${REPO}"
 AUTH_HEADER="Authorization: token ${TOKEN}"
 
 # Get or create release
-RELEASE_ID=$(curl -fsSL -H "${AUTH_HEADER}" "${API}/releases/tags/${DATE}" | jq -r '.id' 2>/dev/null || true)
+RELEASE_ID=$(curl -sSL -H "${AUTH_HEADER}" "${API}/releases/tags/${DATE}" | jq -r '.id' 2>/dev/null || true)
 if [[ -z "${RELEASE_ID}" || "${RELEASE_ID}" == "null" ]]; then
   RELEASE_ID=$(curl -fsSL -H "${AUTH_HEADER}" -H 'Content-Type: application/json' \
     -d "{\"tag_name\":\"${DATE}\",\"name\":\"${DATE}\",\"body\":\"${BODY}\"}" \


### PR DESCRIPTION
## Summary
- install jq and create output dir in Docker image
- gracefully handle optional /output directory in dump script
- fix upload_release.sh pathing and jq check

## Testing
- `bash -n upload_release.sh`
- `bash -n dump_qlib_bin.sh`
- `shellcheck upload_release.sh dump_qlib_bin.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a020751610832aabc3f16f71141847