### PR TITLE
Fix Docker action failures and stale release publishing

### DIFF
--- a/.github/workflows/data_update.yml
+++ b/.github/workflows/data_update.yml
@@ -11,16 +11,23 @@ jobs:
 
     steps:
     - name: Run daily update script in container
-      uses: addnab/docker-run-action@v3
-      with:
-        registry: docker.io
-        image: chenditc/investment_data:latest
-        options: --pull always --name daily_dolt_update -v dolt_update:/dolt --rm
-        run: |
-          # Set up Dolt configurations from secrets
+      env:
+        DOLT_CONFIG_GLOBAL_JSON: ${{ secrets.DOLT_CONFIG_GLOBAL_JSON }}
+        DOLT_JWK: ${{ secrets.DOLT_JWK }}
+        TUSHARE: ${{ secrets.TUSHARE }}
+      run: |
+        set -euo pipefail
+        docker rm -f daily_dolt_update >/dev/null 2>&1 || true
+        docker run --pull always --name daily_dolt_update -v dolt_update:/dolt --rm \
+          -e DOLT_CONFIG_GLOBAL_JSON \
+          -e DOLT_JWK \
+          -e TUSHARE \
+          chenditc/investment_data:latest \
+          bash -lc '
+          set -euo pipefail
           mkdir -p /root/.dolt/creds
-          echo '${{ secrets.DOLT_CONFIG_GLOBAL_JSON }}' > /root/.dolt/config_global.json
-          echo '${{ secrets.DOLT_JWK }}' > /root/.dolt/creds/j6ooicvf6t6a0c18pinnr0p6ao69eglbcsfmmh2247d50.jwk
+          printf "%s\n" "$DOLT_CONFIG_GLOBAL_JSON" > /root/.dolt/config_global.json
+          printf "%s\n" "$DOLT_JWK" > /root/.dolt/creds/j6ooicvf6t6a0c18pinnr0p6ao69eglbcsfmmh2247d50.jwk
 
-          # Execute the daily update script
-          bash -c "TUSHARE=${{ secrets.TUSHARE }} bash daily_update.sh"
+          bash daily_update.sh
+          '

--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -20,13 +20,26 @@ jobs:
     - name: Save current date
       id: date
       run: echo "date=${{ steps.t1.outputs.time }}" >> $GITHUB_OUTPUT
-    - uses: addnab/docker-run-action@v3
-      with:
-        registry: docker.io
-        image: chenditc/investment_data:latest
-        options: --rm --name upload_tar --pull always -v ${{ github.workspace }}:/output -v dolt-vol:/dolt -e HTTP_PROXY -e http_proxy -e HTTPS_PROXY -e https_proxy -e NO_PROXY -e no_proxy
-        run: |
-          bash -cxe "git config --global http.proxy ${http_proxy} && git config --global https.proxy ${https_proxy} && bash dump_qlib_bin.sh && ls -lh /output/"
+    - name: Build qlib binary archive
+      run: |
+        set -euo pipefail
+        docker rm -f upload_tar >/dev/null 2>&1 || true
+        docker run --rm --name upload_tar --pull always \
+          -v "${{ github.workspace }}:/output" \
+          -v dolt-vol:/dolt \
+          -e HTTP_PROXY \
+          -e http_proxy \
+          -e HTTPS_PROXY \
+          -e https_proxy \
+          -e NO_PROXY \
+          -e no_proxy \
+          -e CHECK_FRESHNESS=1 \
+          chenditc/investment_data:latest \
+          bash -lc 'set -euo pipefail
+          git config --global http.proxy "${http_proxy:-}"
+          git config --global https.proxy "${https_proxy:-}"
+          bash dump_qlib_bin.sh
+          ls -lh /output/'
     - name: Upload binaries to release
       uses: svenstaro/upload-release-action@v2
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.9
 
-RUN wget https://github.com/dolthub/dolt/releases/download/v1.30.4/dolt-linux-amd64.tar.gz -O /tmp/dolt-linux-amd64.tar.gz && cd /tmp && tar -zxvf /tmp/dolt-linux-amd64.tar.gz && cp /tmp/dolt-linux-amd64/bin/dolt /usr/bin/ && rm -rf /tmp/* && dolt config --global --add user.email "dockeruser@na.com" && dolt config --global --add user.name "dockeruser"
+ARG DOLT_VERSION=1.88.0
+RUN wget https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/dolt-linux-amd64.tar.gz -O /tmp/dolt-linux-amd64.tar.gz && cd /tmp && tar -zxvf /tmp/dolt-linux-amd64.tar.gz && cp /tmp/dolt-linux-amd64/bin/dolt /usr/bin/ && rm -rf /tmp/* && dolt config --global --add user.email "dockeruser@na.com" && dolt config --global --add user.name "dockeruser"
 RUN apt update && apt install -y git psmisc zip gcc g++ jq
 RUN mkdir -p /dolt
 RUN mkdir -p /investment_data

--- a/daily_update.sh
+++ b/daily_update.sh
@@ -4,7 +4,7 @@ set -x
 [ ! -d "/dolt/investment_data" ] && echo "initializing dolt repo" && cd /dolt && dolt clone chenditc/investment_data
 cd /dolt/investment_data
 dolt fetch origin master
-dolt reset origin/master
+dolt reset --hard origin/master
 dolt checkout .
 
 echo "Updating index weight"
@@ -43,4 +43,3 @@ else
     dolt push --force origin master
     echo "Changes committed and pushed."
 fi
-

--- a/dump_qlib_bin.sh
+++ b/dump_qlib_bin.sh
@@ -14,13 +14,15 @@ mkdir -p $WORKING_DIR/dolt
 [ ! -d "$WORKING_DIR/qlib" ] && git clone $QLIB_REPO "$WORKING_DIR/qlib"
 
 cd $WORKING_DIR/dolt/investment_data
-dolt pull origin master
+dolt fetch origin master
+dolt reset --hard origin/master
 dolt sql-server &
 
 # wait for sql server start
 sleep 5s
 
 cd $WORKING_DIR/investment_data
+rm -rf "$WORKING_DIR/qlib_bin" ./qlib/qlib_source ./qlib/qlib_normalize ./qlib/qlib_index
 mkdir -p ./qlib/qlib_source
 python3 ./qlib/dump_all_to_qlib_source.py
 
@@ -34,6 +36,29 @@ python3 ./dump_index_weight.py
 
 cd $WORKING_DIR/investment_data
 python3 ./tushare/dump_day_calendar.py $WORKING_DIR/qlib_bin/
+
+if [ "${CHECK_FRESHNESS:-0}" = "1" ]; then
+    cd $WORKING_DIR/dolt/investment_data
+    source_max_date=$(dolt sql -r csv -q "SELECT MAX(tradedate) AS max_date FROM final_a_stock_eod_price" | tail -n 1)
+    expected_max_date=$(dolt sql -r csv -q "SELECT MAX(date) AS max_date FROM ts_trade_day_calendar WHERE exchange = 'SSE' AND is_open = 1 AND date <= CURRENT_DATE" | tail -n 1)
+    qlib_max_date=$(tail -n 1 "$WORKING_DIR/qlib_bin/calendars/day.txt")
+
+    echo "Expected latest trade date: ${expected_max_date}"
+    echo "Dolt source latest trade date: ${source_max_date}"
+    echo "Qlib archive latest trade date: ${qlib_max_date}"
+
+    if [ "$source_max_date" != "$expected_max_date" ]; then
+        echo "Dolt source data is stale; refusing to publish release." >&2
+        exit 1
+    fi
+
+    if [ "$qlib_max_date" != "$source_max_date" ]; then
+        echo "Qlib archive is stale; refusing to publish release." >&2
+        exit 1
+    fi
+    cd $WORKING_DIR/investment_data
+fi
+
 killall dolt
 
 cp qlib/qlib_index/csi* $WORKING_DIR/qlib_bin/instruments/

--- a/upload_release.sh
+++ b/upload_release.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -exuo pipefail
+set -euo pipefail
 
 # Configure git proxy if http_proxy or https_proxy are set
 if [[ -n "${http_proxy-}" ]]; then
@@ -21,7 +21,7 @@ fi
 # Determine repository (owner/repo)
 REPO="${REPO:-${GITHUB_REPOSITORY:-chenditc/investment_data}}"
 
-DATE=$(date +%F)
+DATE="${DATE:-$(date +%F)}"
 ASSET_NAME="qlib_bin.tar.gz"
 BODY="Daily update release"
 
@@ -31,8 +31,9 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
-# Run dump script to generate the tarball
-bash dump_qlib_bin.sh
+# Run dump script to generate the tarball. Release uploads should fail closed
+# when the source data or generated archive is stale.
+CHECK_FRESHNESS="${CHECK_FRESHNESS:-1}" bash dump_qlib_bin.sh
 
 FILE_PATH="$(pwd)/${ASSET_NAME}"
 if [[ ! -f "${FILE_PATH}" ]]; then
@@ -46,7 +47,7 @@ AUTH_HEADER="Authorization: token ${TOKEN}"
 # Get or create release
 RELEASE_ID=$(curl -sSL -H "${AUTH_HEADER}" "${API}/releases/tags/${DATE}" | jq -r '.id' 2>/dev/null || true)
 if [[ -z "${RELEASE_ID}" || "${RELEASE_ID}" == "null" ]]; then
-  RELEASE_ID=$(curl -fsSL -H "${AUTH_HEADER}" -H 'Content-Type: application/json' \
+  RELEASE_ID=$(curl -fsSL --retry 3 --retry-delay 10 -H "${AUTH_HEADER}" -H 'Content-Type: application/json' \
     -d "{\"tag_name\":\"${DATE}\",\"name\":\"${DATE}\",\"body\":\"${BODY}\"}" \
     "${API}/releases" | jq -r '.id')
 fi
@@ -63,10 +64,52 @@ if [[ -n "${ASSET_ID}" ]]; then
   curl -fsSL -X DELETE -H "${AUTH_HEADER}" "${API}/releases/assets/${ASSET_ID}" >/dev/null
 fi
 
-# Upload new asset
+# Upload new asset with retry
 UPLOAD_URL=$(curl -fsSL -H "${AUTH_HEADER}" "${API}/releases/${RELEASE_ID}" | jq -r '.upload_url' | sed 's/{?name,label}//')
 
-curl -fsSL -H "${AUTH_HEADER}" -H "Content-Type: application/gzip" \
-  --data-binary "@${FILE_PATH}" "${UPLOAD_URL}?name=${ASSET_NAME}" >/dev/null
+MAX_RETRIES=3
+for attempt in $(seq 1 ${MAX_RETRIES}); do
+  echo "Upload attempt ${attempt}/${MAX_RETRIES}..."
+  HTTP_CODE=$(curl -sS -o /tmp/upload_response.json -w "%{http_code}" \
+    -H "${AUTH_HEADER}" -H "Content-Type: application/gzip" \
+    --data-binary "@${FILE_PATH}" "${UPLOAD_URL}?name=${ASSET_NAME}")
 
-echo "Uploaded ${ASSET_NAME} to release ${DATE}"
+  if [[ "${HTTP_CODE}" =~ ^2 ]]; then
+    echo "Upload succeeded (HTTP ${HTTP_CODE})"
+    break
+  fi
+
+  echo "Upload failed (HTTP ${HTTP_CODE}), response:" >&2
+  cat /tmp/upload_response.json >&2
+  echo >&2
+
+  if [[ "${attempt}" -eq "${MAX_RETRIES}" ]]; then
+    echo "Error: upload failed after ${MAX_RETRIES} attempts." >&2
+    exit 1
+  fi
+
+  ASSET_ID=$(curl -fsSL -H "${AUTH_HEADER}" "${API}/releases/${RELEASE_ID}/assets" | jq -r \
+    ".[] | select(.name==\"${ASSET_NAME}\") | .id")
+  if [[ -n "${ASSET_ID}" ]]; then
+    curl -fsSL -X DELETE -H "${AUTH_HEADER}" "${API}/releases/assets/${ASSET_ID}" >/dev/null
+    echo "Deleted partial asset before retry"
+  fi
+
+  sleep 30
+done
+
+UPLOADED_SIZE=$(curl -fsSL -H "${AUTH_HEADER}" "${API}/releases/${RELEASE_ID}/assets" | jq -r \
+  ".[] | select(.name==\"${ASSET_NAME}\") | .size")
+LOCAL_SIZE=$(stat -c%s "${FILE_PATH}" 2>/dev/null || stat -f%z "${FILE_PATH}")
+
+if [[ -z "${UPLOADED_SIZE}" || "${UPLOADED_SIZE}" == "null" ]]; then
+  echo "Error: asset not found in release after upload." >&2
+  exit 1
+fi
+
+if [[ "${UPLOADED_SIZE}" -ne "${LOCAL_SIZE}" ]]; then
+  echo "Error: size mismatch - local=${LOCAL_SIZE} uploaded=${UPLOADED_SIZE}" >&2
+  exit 1
+fi
+
+echo "Verified: uploaded ${ASSET_NAME} (${UPLOADED_SIZE} bytes) to release ${DATE}"


### PR DESCRIPTION
## Summary
- replace addnab/docker-run-action usage with host docker run so the self-hosted runner uses the upgraded Docker CLI
- upgrade the Docker image Dolt version and force persisted Dolt clones back to origin/master before update/export
- clean stale qlib output directories before building release archives
- add qlib release freshness checks against Dolt source max date and SSE trading calendar expected date
- make the cron release script fail closed by default, allow DATE override for repairs, retry uploads, verify uploaded asset size, and stop shell tracing PAT-bearing curl commands

Fixes #135

## Validation
- bash -n daily_update.sh dump_qlib_bin.sh upload_release.sh
- parsed .github/workflows/data_update.yml and .github/workflows/upload_release.yml with PyYAML
- git diff --check
- patched the running upload-qlib-tar container with the same script changes and Dolt 1.88.0
- refreshed dolt-vol to max tradedate 2026-05-06
- regenerated 2026-05-06 release asset; qlib calendar max date is now 2026-05-06
