### PR TITLE
fix(#148): prevent stale qlib release data

### DIFF
--- a/.github/workflows/data_update.yml
+++ b/.github/workflows/data_update.yml
@@ -6,7 +6,7 @@ on:
     - cron: '30 * * * *' # Runs at 30 minutes past the hour, every hour
 
 concurrency:
-  group: investment-data-update
+  group: investment-data-dolt-volume
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Check out exact source commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       -
@@ -27,5 +32,10 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v3
         with:
-          push: true
-          tags: chenditc/investment_data:latest
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            INVESTMENT_DATA_REVISION=${{ github.sha }}
+          tags: |
+            chenditc/investment_data:latest
+            chenditc/investment_data:sha-${{ github.sha }}

--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -2,56 +2,80 @@ name: Upload latest data to github release
 
 on:
   workflow_dispatch:
+    inputs:
+      operation:
+        required: true
+        type: choice
+        default: publish
+        options:
+          - publish
+          - repair-2026-07-20
   schedule:
-    - cron: '1 11 * * *' # 19:01 Asia/Shanghai, matches the legacy serv1 cron
+    - cron: '1 11 * * *' # 19:01 Asia/Shanghai
 
 concurrency:
-  group: investment-data-release-upload
+  group: investment-data-dolt-volume
   cancel-in-progress: false
 
 jobs:
-  build:
+  publish:
     runs-on: investment-arc
-    timeout-minutes: 90
+    timeout-minutes: 180
     permissions:
       contents: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      OPERATION: ${{ github.event_name == 'schedule' && 'publish' || inputs.operation }}
 
     steps:
-    - name: Get current UTC date
-      id: date
-      run: echo "date=$(date -u +%F)" >> "$GITHUB_OUTPUT"
-    - name: Build qlib binary archive
-      env:
-        # Keep the migrated workflow aligned with the legacy serv1 cron behavior.
-        # Data freshness is driven by the upstream data_update cadence rather than
-        # hard-failing release publication on the current calendar date.
-        CHECK_FRESHNESS: "0"
-      run: |
-        set -euo pipefail
-        docker rm -f upload_tar >/dev/null 2>&1 || true
-        docker volume inspect dolt_update >/dev/null 2>&1 || docker volume create dolt_update >/dev/null
-        docker run --rm --name upload_tar --pull always \
-          -v "${{ github.workspace }}:/output" \
-          -v dolt_update:/dolt \
-          -e HTTP_PROXY \
-          -e http_proxy \
-          -e HTTPS_PROXY \
-          -e https_proxy \
-          -e NO_PROXY \
-          -e no_proxy \
-          -e CHECK_FRESHNESS \
-          chenditc/investment_data:latest \
-          bash -lc 'set -euo pipefail
-          git config --global http.proxy "${http_proxy:-}"
-          git config --global https.proxy "${https_proxy:-}"
-          bash dump_qlib_bin.sh
-          ls -lh /output/'
-    - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GH_TOKEN }}
-        file: ${{ github.workspace }}/qlib_bin.tar.gz
-        asset_name: qlib_bin.tar.gz
-        tag: ${{ steps.date.outputs.date }}
-        overwrite: true
-        body: "Daily update release"
+      - name: Resolve and verify immutable publication image
+        id: image
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REPOSITORY" == "chenditc/investment_data" ]]
+          [[ "$GITHUB_REF" == "refs/heads/main" ]]
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$GITHUB_EVENT_NAME" == "schedule" || "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]
+          [[ "$OPERATION" == "publish" || "$OPERATION" == "repair-2026-07-20" ]]
+          if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
+            [[ "$OPERATION" == "publish" ]]
+          fi
+
+          image_tag="chenditc/investment_data:sha-${GITHUB_SHA}"
+          docker pull "$image_tag"
+          image_digest="$(docker image inspect "$image_tag" --format '{{json .RepoDigests}}' \
+            | jq -er '[.[] | select(test("^chenditc/investment_data@sha256:[0-9a-f]{64}$"))] | if length == 1 then .[0] | split("@")[1] else error("ambiguous digest") end')"
+          repository_revision="$(docker image inspect "$image_tag" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
+          qlib_revision="$(docker image inspect "$image_tag" --format '{{ index .Config.Labels "io.chenditc.investment-data.qlib-revision" }}')"
+          [[ "$image_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          [[ "$repository_revision" == "$GITHUB_SHA" ]]
+          [[ "$qlib_revision" == "b87a2c294d364a33fb739359886acffe8ec907d1" ]]
+          printf 'digest=%s\n' "$image_digest" >>"$GITHUB_OUTPUT"
+          printf 'repository_revision=%s\n' "$repository_revision" >>"$GITHUB_OUTPUT"
+          printf 'qlib_revision=%s\n' "$qlib_revision" >>"$GITHUB_OUTPUT"
+
+      - name: Build, validate, and publish release assets
+        shell: bash
+        env:
+          PUBLICATION_IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+          PUBLICATION_BAKED_REPOSITORY_REVISION: ${{ steps.image.outputs.repository_revision }}
+          PUBLICATION_BAKED_QLIB_REVISION: ${{ steps.image.outputs.qlib_revision }}
+        run: |
+          set -euo pipefail
+          docker rm -f upload_tar >/dev/null 2>&1 || true
+          docker volume inspect dolt_update >/dev/null 2>&1 || docker volume create dolt_update >/dev/null
+          args=()
+          if [[ "$OPERATION" == "repair-2026-07-20" ]]; then
+            args=(repair-2026-07-20)
+          fi
+          docker run --rm --name upload_tar \
+            -v dolt_update:/dolt \
+            -e HTTP_PROXY -e http_proxy -e HTTPS_PROXY -e https_proxy -e NO_PROXY -e no_proxy \
+            -e GITHUB_ACTIONS -e GITHUB_EVENT_NAME -e GITHUB_REPOSITORY -e GITHUB_REF \
+            -e GITHUB_SHA -e GITHUB_RUN_ID -e GITHUB_RUN_ATTEMPT -e GITHUB_TOKEN \
+            -e PUBLICATION_IMAGE_DIGEST \
+            -e PUBLICATION_BAKED_REPOSITORY_REVISION \
+            -e PUBLICATION_BAKED_QLIB_REVISION \
+            "chenditc/investment_data@${PUBLICATION_IMAGE_DIGEST}" \
+            bash upload_release.sh "${args[@]}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,55 @@
 FROM python:3.9
 
 ARG DOLT_VERSION=1.88.0
-RUN wget https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/dolt-linux-amd64.tar.gz -O /tmp/dolt-linux-amd64.tar.gz && cd /tmp && tar -zxvf /tmp/dolt-linux-amd64.tar.gz && cp /tmp/dolt-linux-amd64/bin/dolt /usr/bin/ && rm -rf /tmp/* && dolt config --global --add user.email "dockeruser@na.com" && dolt config --global --add user.name "dockeruser"
-RUN apt update && apt install -y git psmisc zip gcc g++ jq
-RUN mkdir -p /dolt
-RUN mkdir -p /investment_data
+ARG INVESTMENT_DATA_REVISION
+ARG QLIB_REVISION=b87a2c294d364a33fb739359886acffe8ec907d1
 
-RUN cd /investment_data && git init && git pull https://github.com/chenditc/investment_data.git
-RUN  pip install numpy==1.23.5 && pip install --upgrade cython \
-   && cd / && git clone https://github.com/microsoft/qlib.git && mv /qlib /qlib_source \
-   && cd /qlib_source/ && pip install -e .[dev] && pip install -r scripts/data_collector/yahoo/requirements.txt 
+LABEL org.opencontainers.image.revision="${INVESTMENT_DATA_REVISION}"
+LABEL io.chenditc.investment-data.qlib-revision="${QLIB_REVISION}"
+
+RUN case "${INVESTMENT_DATA_REVISION}" in \
+      [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;; \
+      *) echo "INVESTMENT_DATA_REVISION must be a lowercase 40-hex commit" >&2; exit 1 ;; \
+    esac \
+    && test "${QLIB_REVISION}" = "b87a2c294d364a33fb739359886acffe8ec907d1"
+
+RUN wget "https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/dolt-linux-amd64.tar.gz" -O /tmp/dolt-linux-amd64.tar.gz \
+    && cd /tmp \
+    && tar -zxvf /tmp/dolt-linux-amd64.tar.gz \
+    && cp /tmp/dolt-linux-amd64/bin/dolt /usr/bin/ \
+    && rm -rf /tmp/* \
+    && dolt config --global --add user.email "dockeruser@na.com" \
+    && dolt config --global --add user.name "dockeruser"
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl git psmisc zip gcc g++ jq util-linux \
+    && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /dolt /investment_data /opt/investment-data
+
+RUN pip install numpy==1.23.5 \
+    && pip install --upgrade cython \
+    && git clone https://github.com/microsoft/qlib.git /qlib \
+    && git -C /qlib checkout --detach "${QLIB_REVISION}" \
+    && test "$(git -C /qlib rev-parse HEAD)" = "${QLIB_REVISION}" \
+    && pip install -e '/qlib[dev]' \
+    && pip install -r /qlib/scripts/data_collector/yahoo/requirements.txt
+
 COPY ./requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt
 COPY . /investment_data/
 
-# Add a global sitecustomize.py so every Python process defaults to "spawn"
+RUN test "$(git -C /investment_data rev-parse HEAD)" = "${INVESTMENT_DATA_REVISION}" \
+    && printf '%s\n' "${INVESTMENT_DATA_REVISION}" > /opt/investment-data/REVISION \
+    && printf '%s\n' "${QLIB_REVISION}" > /opt/investment-data/QLIB_REVISION \
+    && chmod 0444 /opt/investment-data/REVISION /opt/investment-data/QLIB_REVISION \
+    && PYTHONPATH=/qlib:/qlib/scripts python3 -m unittest discover -s /investment_data/tests -p test_qlib_normalize.py
+
+# Add a global sitecustomize.py so every Python process defaults to "spawn".
 RUN printf '%s\n' \
-'import multiprocessing as mp' \
-'try:' \
-'    mp.set_start_method("spawn")' \
-'except RuntimeError:' \
-'    # Already set by someone else (or on Windows/macOS default)' \
-'    pass' \
-> /usr/local/lib/python3.9/site-packages/sitecustomize.py
+    'import multiprocessing as mp' \
+    'try:' \
+    '    mp.set_start_method("spawn")' \
+    'except RuntimeError:' \
+    '    pass' \
+    > /usr/local/lib/python3.9/site-packages/sitecustomize.py
 
 WORKDIR /investment_data/

--- a/README.md
+++ b/README.md
@@ -34,10 +34,17 @@ If you are willing to sponsor the VPS fee, you can donate in this page: https://
 Thanks for everyone's help.
 
 # How to use it
-1. Download tar ball from latest release page on github
-2. Extract tar file to default qlib directory
+1. Download the canonical archive and its provenance manifest from the same GitHub release.
+2. Validate the completed archive bytes and date-bearing members.
+3. Extract the canonical archive to the default qlib directory.
 ```
-wget https://github.com/chenditc/investment_data/releases/download/2023-10-08/qlib_bin.tar.gz
+wget "https://github.com/chenditc/investment_data/releases/download/<release-tag>/qlib_bin.tar.gz"
+wget "https://github.com/chenditc/investment_data/releases/download/<release-tag>/qlib_bin.manifest.json"
+python3 qlib/validate_archive.py \
+  --archive qlib_bin.tar.gz \
+  --manifest qlib_bin.manifest.json \
+  --expected-tag "<release-tag>" \
+  --require-publishable
 tar -zxvf qlib_bin.tar.gz -C ~/.qlib/qlib_data/cn_data --strip-components=1
 ```
 
@@ -56,10 +63,15 @@ To download as dolt database:
 
 ## Export to qlib format
 ```
-docker run 
-  -v /<some output directory>:/output
-  -it --rm chenditc/investment_data bash dump_qlib_bin.sh && cp ./qlib_bin.tar.gz /output/
+docker run \
+  -v /<some output directory>:/output \
+  -it --rm chenditc/investment_data bash dump_qlib_bin.sh
 ```
+
+The standalone diagnostic grammar is `bash dump_qlib_bin.sh [WORKING_DIR [QLIB_REPOSITORY]]`.
+It always creates and validates `qlib_bin.tar.gz` together with
+`qlib_bin.manifest.json`. A standalone manifest has `image_digest:null`, so it
+is suitable for local inspection but cannot be published as a release asset.
 
 You can use the following parameter to mount an existing dolt chenditc/investment_data folder to the container.
 ```
@@ -76,15 +88,36 @@ bash daily_update.sh
 
 ## Daily update and output
 ```
-docker run -v /<some output directory>:/output -it --rm chenditc/investment_data bash daily_update.sh && bash dump_qlib_bin.sh && cp ./qlib_bin.tar.gz /output/
+docker run -v /<some output directory>:/output -it --rm chenditc/investment_data \
+  bash -lc 'bash daily_update.sh && bash dump_qlib_bin.sh'
 ```
 
 ## Upload to GitHub release
-Generate the tarball and upload it to the repository's release page without GitHub Actions:
+Release publication is authorized only by the digest-pinned workflow on `main`.
+Dispatch the normal publisher with:
 
 ```
-docker run --rm -e GITHUB_PAT=<token> chenditc/investment_data bash upload_release.sh
+gh workflow run upload_release.yml --repo chenditc/investment_data --ref main -f operation=publish
 ```
+
+`upload_release.sh` is workflow-internal and rejects direct/local/container
+publication. The workflow validates the ten-field manifest and the complete
+archive before any release mutation, then redownloads and validates both
+canonical assets.
+
+### Fail-safe repository rollback
+
+A full repository revert is ordered and fail-closed:
+
+1. Run `gh workflow disable upload_release.yml --repo chenditc/investment_data`.
+2. Query `gh workflow view upload_release.yml --repo chenditc/investment_data --json state --jq .state` and require the exact result `disabled_manually`.
+3. Query both `upload_release.yml` and `data_update.yml` runs and wait until every queued or in-progress job using the shared Dolt volume has drained.
+4. Perform the full repository revert.
+5. Run `gh workflow view upload_release.yml --repo chenditc/investment_data --json state --jq .state` again and require `disabled_manually`.
+6. Do not re-enable publication until validator-backed digest pinning, workflow authority, and shared concurrency/filesystem locking are restored and verified end to end.
+
+The revert may move the convenience `latest` image and therefore affect data update, but it cannot publish while the upload workflow is disabled. Draining is mandatory because a full revert may remove the shared lock and concurrency group. Already accepted release assets are untouched. An interrupted historical repair may complete only through the fixed `repair-2026-07-20` operation, and the stale backup is never auto-restored. The deployed monitor is separate external state; roll it back only with the tracked `ops/investment-data-project-monitor/deploy.sh rollback`, never as part of the repository revert.
+
 
 ## Extract tar file to qlib directory
 ```

--- a/daily_update.sh
+++ b/daily_update.sh
@@ -1,8 +1,21 @@
-set -e
+set -euo pipefail
 set -x
 
-[ ! -d "/dolt/investment_data" ] && echo "initializing dolt repo" && cd /dolt && dolt clone chenditc/investment_data
-cd /dolt/investment_data
+DOLT_DIR="/dolt"
+DOLT_LOCK_FILE="${DOLT_DIR}/.investment-data.lock"
+if ! command -v flock >/dev/null 2>&1; then
+    echo "Error: flock is required for the shared Dolt checkout." >&2
+    exit 1
+fi
+mkdir -p "${DOLT_DIR}"
+exec 8>"${DOLT_LOCK_FILE}"
+if ! flock -n 8; then
+    echo "Error: shared Dolt checkout is locked by another workflow." >&2
+    exit 1
+fi
+
+[ ! -d "${DOLT_DIR}/investment_data" ] && echo "initializing dolt repo" && cd "${DOLT_DIR}" && dolt clone chenditc/investment_data
+cd "${DOLT_DIR}/investment_data"
 dolt fetch origin master
 dolt reset --hard origin/master
 dolt checkout .

--- a/docs/README-ch.md
+++ b/docs/README-ch.md
@@ -29,10 +29,17 @@
 
 
 # 如何使用
-1. 从GitHub上的最新发布页面下载tar压缩文件
-2. 将tar文件解压到默认的qlib目录
+1. 从同一个 GitHub Release 下载规范归档和来源清单。
+2. 校验完整归档的字节、日期成员和清单。
+3. 将规范归档解压到默认的 qlib 目录。
 ```
-wget https://github.com/chenditc/investment_data/releases/download/2023-10-08/qlib_bin.tar.gz
+wget "https://github.com/chenditc/investment_data/releases/download/<release-tag>/qlib_bin.tar.gz"
+wget "https://github.com/chenditc/investment_data/releases/download/<release-tag>/qlib_bin.manifest.json"
+python3 qlib/validate_archive.py \
+  --archive qlib_bin.tar.gz \
+  --manifest qlib_bin.manifest.json \
+  --expected-tag "<release-tag>" \
+  --require-publishable
 tar -zxvf qlib_bin.tar.gz -C ~/.qlib/qlib_data/cn_data --strip-components=1
 ```
 
@@ -51,8 +58,13 @@ tar -zxvf qlib_bin.tar.gz -C ~/.qlib/qlib_data/cn_data --strip-components=1
 
 ## 导出为qlib格式
 ```
-docker run -v /<some output directory>:/output -it --rm chenditc/investment_data bash dump_qlib_bin.sh && cp ./qlib_bin.tar.gz /output/
+docker run -v /<some output directory>:/output -it --rm chenditc/investment_data bash dump_qlib_bin.sh
 ```
+
+独立诊断命令的完整参数形式是
+`bash dump_qlib_bin.sh [WORKING_DIR [QLIB_REPOSITORY]]`。它总是成对生成并校验
+`qlib_bin.tar.gz` 与 `qlib_bin.manifest.json`。独立构建的清单中
+`image_digest` 为 `null`，可用于本地检查，但不能发布到 Release。
 
 ## 运行每日更新
 你将需要tushare令牌来使用tushare api。从https://tushare.pro/ 获取tushare令牌。
@@ -64,14 +76,38 @@ bash daily_update.sh
 
 ## 每日更新和输出
 ```
-docker run -v /<some output directory>:/output -it --rm chenditc/investment_data bash daily_update.sh && bash dump_qlib_bin.sh && cp ./qlib_bin.tar.gz /output/
+docker run -v /<some output directory>:/output -it --rm chenditc/investment_data \
+  bash -lc 'bash daily_update.sh && bash dump_qlib_bin.sh'
 ```
+
+## 发布到 GitHub Release
+
+只有 `main` 分支上按镜像摘要固定的工作流具有发布权限。正常发布使用：
+
+```bash
+gh workflow run upload_release.yml --repo chenditc/investment_data --ref main -f operation=publish
+```
+
+`upload_release.sh` 仅供工作流内部使用，会拒绝本地或容器直接发布。工作流在任何
+Release 变更前校验十字段清单和完整归档，并在上传后重新下载、校验两个规范资产。
+
+### 仓库回滚的失效安全顺序
+
+完整仓库回滚必须按以下顺序执行并保持失败关闭：
+
+1. 运行 `gh workflow disable upload_release.yml --repo chenditc/investment_data`。
+2. 运行 `gh workflow view upload_release.yml --repo chenditc/investment_data --json state --jq .state`，并要求结果严格等于 `disabled_manually`。
+3. 查询 `upload_release.yml` 与 `data_update.yml`，等待所有使用共享 Dolt 卷的排队中或运行中任务完全 drain（排空）。
+4. 执行完整仓库 revert。
+5. 再次运行 `gh workflow view upload_release.yml --repo chenditc/investment_data --json state --jq .state`，并要求状态仍严格等于 `disabled_manually`。
+6. 在基于 validator 的摘要固定、工作流 authority、共享 concurrency 和文件锁全部恢复并完成端到端验证前，禁止重新启用发布。
+
+回滚后的便利标签 `latest` 可能影响数据更新，但上传工作流禁用期间不能发布。完整回滚可能移除共享锁与 concurrency group，因此必须先 drain。已经 Accepted 的 Release 资产不会被仓库回滚修改；中断的历史修复只能通过固定的 `repair-2026-07-20` 操作完成；已知陈旧的 backup 永不自动恢复。已部署 monitor 属于独立外部状态，只能另行运行受跟踪的 `ops/investment-data-project-monitor/deploy.sh rollback` 回滚，不能把它耦合到仓库 revert。
+
 
 ## 将tar文件解压到qlib目录
 ```
-tar -zxvf qlib_bin.tar.gz
-
- -C ~/.qlib/qlib_data/cn_data --strip-components=2
+tar -zxvf qlib_bin.tar.gz -C ~/.qlib/qlib_data/cn_data --strip-components=1
 ```
 
 # 初衷

--- a/docs/final_a_stock_eod_price.ch.md
+++ b/docs/final_a_stock_eod_price.ch.md
@@ -11,7 +11,32 @@
 目前，每日更新仅使用tushare数据源，并由github action触发。
 1. 我维护了一个离线任务，它每30分钟运行一次[daily_update.sh](daily_update.sh)以收集数据并推送到dolthub。
 2. 一个github action [.github/workflows/upload_release.yml](.github/workflows/upload_release.yml)每日触发，然后调用bash dump_qlib_bin.sh生成每日tar文件并上传到发布页面。
-   同样的流程也可以在容器内手动执行，运行[upload_release.sh](../upload_release.sh)并提供`GITHUB_PAT`环境变量即可将生成的tar文件上传到GitHub。
+   每次发布都必须成对生成规范的 `qlib_bin.tar.gz` 和
+   `qlib_bin.manifest.json`。工作流在变更 Release 前校验归档中的实际成员和不可变
+   来源信息，并在上传后重新下载、校验这两个资产。`upload_release.sh` 仅供工作流
+   内部使用；运维人员只能通过以下命令触发正常发布：
+
+   ```bash
+   gh workflow run upload_release.yml --repo chenditc/investment_data --ref main -f operation=publish
+   ```
+
+   使用者应下载两个规范资产，先以 `--require-publishable` 运行
+   `qlib/validate_archive.py`，再通过 `tar -zxvf qlib_bin.tar.gz -C
+   ~/.qlib/qlib_data/cn_data --strip-components=1` 将规范归档解压到 qlib 数据目录。
+
+### 仓库回滚的失效安全顺序
+
+完整仓库回滚必须按以下顺序执行并保持失败关闭：
+
+1. 运行 `gh workflow disable upload_release.yml --repo chenditc/investment_data`。
+2. 运行 `gh workflow view upload_release.yml --repo chenditc/investment_data --json state --jq .state`，并要求结果严格等于 `disabled_manually`。
+3. 查询 `upload_release.yml` 与 `data_update.yml`，等待所有使用共享 Dolt 卷的排队中或运行中任务完全 drain（排空）。
+4. 执行完整仓库 revert。
+5. 再次运行 `gh workflow view upload_release.yml --repo chenditc/investment_data --json state --jq .state`，并要求状态仍严格等于 `disabled_manually`。
+6. 在基于 validator 的摘要固定、工作流 authority、共享 concurrency 和文件锁全部恢复并完成端到端验证前，禁止重新启用发布。
+
+回滚后的便利标签 `latest` 可能影响数据更新，但上传工作流禁用期间不能发布。完整回滚可能移除共享锁与 concurrency group，因此必须先 drain。已经 Accepted 的 Release 资产不会被仓库回滚修改；中断的历史修复只能通过固定的 `repair-2026-07-20` 操作完成；已知陈旧的 backup 永不自动恢复。已部署 monitor 属于独立外部状态，只能另行运行受跟踪的 `ops/investment-data-project-monitor/deploy.sh rollback` 回滚，不能把它耦合到仓库 revert。
+
 
 ## 合并逻辑
 1. 使用w数据源作为基准，使用其他数据源进行验证。

--- a/docs/final_a_stock_eod_price.md
+++ b/docs/final_a_stock_eod_price.md
@@ -12,7 +12,34 @@
 Currently the daily update is only using tushare data source and triggered by github action.
 1. I maintained a offline job whcih runs [daily_update.sh](daily_update.sh) every 30 mins to collect data and push to dolthub.
 2. A github action [.github/workflows/upload_release.yml](.github/workflows/upload_release.yml) is triggered daily, which then calls bash dump_qlib_bin.sh to generate daily tar file and upload to release page.
-   The same process can be executed manually inside the container by running [upload_release.sh](../upload_release.sh), which expects a `GITHUB_PAT` environment variable and uploads the generated tarball to GitHub.
+   Publication always produces the canonical `qlib_bin.tar.gz` and
+   `qlib_bin.manifest.json` pair. The workflow validates actual archive members
+   and immutable provenance before mutation, then redownloads and validates the
+   published pair. `upload_release.sh` is workflow-internal; operators dispatch
+   normal publication only with:
+
+   ```bash
+   gh workflow run upload_release.yml --repo chenditc/investment_data --ref main -f operation=publish
+   ```
+
+   Consumers download both canonical assets, run `qlib/validate_archive.py`
+   with `--require-publishable`, then extract `qlib_bin.tar.gz` into the qlib
+   data directory with `tar -zxvf qlib_bin.tar.gz -C
+   ~/.qlib/qlib_data/cn_data --strip-components=1`.
+
+### Fail-safe repository rollback
+
+A full repository revert is ordered and fail-closed:
+
+1. Run `gh workflow disable upload_release.yml --repo chenditc/investment_data`.
+2. Query `gh workflow view upload_release.yml --repo chenditc/investment_data --json state --jq .state` and require the exact result `disabled_manually`.
+3. Query both `upload_release.yml` and `data_update.yml` runs and wait until every queued or in-progress job using the shared Dolt volume has drained.
+4. Perform the full repository revert.
+5. Run `gh workflow view upload_release.yml --repo chenditc/investment_data --json state --jq .state` again and require `disabled_manually`.
+6. Do not re-enable publication until validator-backed digest pinning, workflow authority, and shared concurrency/filesystem locking are restored and verified end to end.
+
+The revert may move the convenience `latest` image and therefore affect data update, but it cannot publish while the upload workflow is disabled. Draining is mandatory because a full revert may remove the shared lock and concurrency group. Already accepted release assets are untouched. An interrupted historical repair may complete only through the fixed `repair-2026-07-20` operation, and the stale backup is never auto-restored. The deployed monitor is separate external state; roll it back only with the tracked `ops/investment-data-project-monitor/deploy.sh rollback`, never as part of the repository revert.
+
 
 ## Merge logic
 1. Use w data source as baseline, use other data source to validate against it.

--- a/dump_qlib_bin.sh
+++ b/dump_qlib_bin.sh
@@ -1,120 +1,413 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "${TRACE:-0}" = "1" ]; then
-    set -x
+usage() {
+    printf 'usage: %s [WORKING_DIR [QLIB_REPOSITORY]]\n' "${0##*/}" >&2
+}
+
+if (($# > 2)); then
+    usage
+    exit 2
 fi
 
-WORKING_DIR=${1:-}
-QLIB_REPO=${2:-https://github.com/microsoft/qlib.git}
-INVESTMENT_DATA_DIR="${WORKING_DIR}/investment_data"
-DOLT_DIR="${WORKING_DIR}/dolt"
-QLIB_REPO_DIR="${WORKING_DIR}/qlib"
-RUN_ID="${QLIB_BUILD_ID:-$(date +%Y%m%d%H%M%S)-$$}"
-BUILD_ROOT="${QLIB_BUILD_ROOT:-${WORKING_DIR}/qlib_build_${RUN_ID}}"
-QLIB_SOURCE_DIR="${BUILD_ROOT}/qlib_source"
-QLIB_NORMALIZE_DIR="${BUILD_ROOT}/qlib_normalize"
-QLIB_INDEX_DIR="${BUILD_ROOT}/qlib_index"
-QLIB_BIN_DIR="${BUILD_ROOT}/qlib_bin"
+for rejected in QLIB_BUILD_ID QLIB_BUILD_ROOT CLEAN_QLIB_BUILD_ROOT CHECK_FRESHNESS; do
+    if [[ -v "$rejected" ]]; then
+        printf 'Error: %s is not a supported dump input.\n' "$rejected" >&2
+        exit 2
+    fi
+done
+
+case "${TRACE:-0}" in
+    0) ;;
+    1) set -x ;;
+    *) printf 'Error: TRACE must be 0 or 1.\n' >&2; exit 2 ;;
+esac
+if [[ ! "${DUMP_QLIB_MAX_WORKERS:-8}" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'Error: DUMP_QLIB_MAX_WORKERS must be a positive decimal integer.\n' >&2
+    exit 2
+fi
 DUMP_QLIB_MAX_WORKERS="${DUMP_QLIB_MAX_WORKERS:-8}"
+
+if [[ -v OUTPUT_DIR ]] && { [[ ! -d "$OUTPUT_DIR" ]] || [[ ! -w "$OUTPUT_DIR" ]]; }; then
+    printf 'Error: OUTPUT_DIR must be an existing writable directory.\n' >&2
+    exit 2
+fi
+
+WORKING_ROOT="${1:-/}"
+[[ -n "$WORKING_ROOT" ]] || WORKING_ROOT="/"
+if [[ ! -d "$WORKING_ROOT" ]]; then
+    printf 'Error: working root does not exist: %s\n' "$WORKING_ROOT" >&2
+    exit 1
+fi
+WORKING_ROOT="$(cd "$WORKING_ROOT" && pwd -P)"
+QLIB_REPOSITORY="${2:-https://github.com/microsoft/qlib.git}"
+INVESTMENT_DATA_DIR="${WORKING_ROOT%/}/investment_data"
+DOLT_DIR="${WORKING_ROOT%/}/dolt"
+QLIB_REPO_DIR="${WORKING_ROOT%/}/qlib"
+SHARED_DOLT_CHECKOUT="${DOLT_DIR}/investment_data"
+DOLT_LOCK_FILE="${DOLT_DIR}/.investment-data.lock"
+QLIB_COMMIT="b87a2c294d364a33fb739359886acffe8ec907d1"
 DOLT_SQL_SERVER_PID=""
+BUILD_ROOT=""
+
+if [[ ! -d "$INVESTMENT_DATA_DIR/.git" ]]; then
+    printf 'Error: investment_data checkout not found at %s.\n' "$INVESTMENT_DATA_DIR" >&2
+    exit 1
+fi
+
+publication_values=(
+    BUILD_RELEASE_TAG
+    BUILD_INVESTMENT_DATA_COMMIT
+    BUILD_QLIB_COMMIT
+    BUILD_IMAGE_DIGEST
+    BUILD_DOLT_COMMIT
+)
+publication_count=0
+for variable in "${publication_values[@]}"; do
+    [[ -v "$variable" ]] && ((publication_count += 1))
+done
+if ((publication_count != 0 && publication_count != ${#publication_values[@]})); then
+    printf 'Error: publication build authority must be supplied as one complete tuple.\n' >&2
+    exit 2
+fi
+PUBLISHABLE=false
+if ((publication_count == ${#publication_values[@]})); then
+    PUBLISHABLE=true
+    if [[ "${GITHUB_ACTIONS:-}" != "true" ]] \
+        || [[ ! "${BUILD_RELEASE_TAG}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] \
+        || [[ ! "${BUILD_INVESTMENT_DATA_COMMIT}" =~ ^[0-9a-f]{40}$ ]] \
+        || [[ "${BUILD_QLIB_COMMIT}" != "$QLIB_COMMIT" ]] \
+        || [[ ! "${BUILD_IMAGE_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+        || [[ ! "${BUILD_DOLT_COMMIT}" =~ ^[0-9a-v]{32}$ ]]; then
+        printf 'Error: malformed publication build authority.\n' >&2
+        exit 2
+    fi
+    if [[ "${PUBLICATION_IMAGE_DIGEST:-}" != "$BUILD_IMAGE_DIGEST" ]] \
+        || [[ "${PUBLICATION_BAKED_REPOSITORY_REVISION:-}" != "$BUILD_INVESTMENT_DATA_COMMIT" ]] \
+        || [[ "${PUBLICATION_BAKED_QLIB_REVISION:-}" != "$BUILD_QLIB_COMMIT" ]]; then
+        printf 'Error: publication build authority does not match launcher evidence.\n' >&2
+        exit 1
+    fi
+fi
 
 cleanup() {
-    if [ -n "${DOLT_SQL_SERVER_PID}" ]; then
-        kill "${DOLT_SQL_SERVER_PID}" >/dev/null 2>&1 || true
-        wait "${DOLT_SQL_SERVER_PID}" >/dev/null 2>&1 || true
+    local status=$?
+    if [[ -n "$DOLT_SQL_SERVER_PID" ]]; then
+        kill "$DOLT_SQL_SERVER_PID" >/dev/null 2>&1 || true
+        wait "$DOLT_SQL_SERVER_PID" >/dev/null 2>&1 || true
     fi
-    if [ "${CLEAN_QLIB_BUILD_ROOT:-1}" = "1" ]; then
-        rm -rf "${BUILD_ROOT}"
+    if [[ -n "$BUILD_ROOT" && -d "$BUILD_ROOT" ]]; then
+        rm -rf -- "$BUILD_ROOT"
     fi
+    exit "$status"
 }
 trap cleanup EXIT
 
 log_step() {
-    echo "[$(date -Is)] $*"
+    printf '[%s] %s\n' "$(date -Is)" "$*"
 }
 
-if ! command -v dolt &> /dev/null
-then
-    curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash
+canonical_date() {
+    local value=$1
+    [[ "$value" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] \
+        && [[ "$(date -u -d "$value" +%F 2>/dev/null)" == "$value" ]]
+}
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        printf 'Error: required command is unavailable: %s\n' "$1" >&2
+        exit 1
+    fi
+}
+
+for command in dolt find git flock python3 sort tar gzip sha256sum stat mktemp touch; do
+    require_command "$command"
+done
+
+mkdir -p "$DOLT_DIR"
+exec 8>"$DOLT_LOCK_FILE" || {
+    printf 'Error: cannot open Dolt checkout lock.\n' >&2
+    exit 1
+}
+if ! flock -n 8; then
+    printf 'Error: Dolt checkout lock is held by another process.\n' >&2
+    exit 1
 fi
 
-mkdir -p "${DOLT_DIR}"
+if [[ ! -d "$SHARED_DOLT_CHECKOUT/.dolt" ]]; then
+    log_step "Cloning Dolt data"
+    (cd "$DOLT_DIR" && dolt clone chenditc/investment_data)
+fi
+if ! (cd "$SHARED_DOLT_CHECKOUT" && dolt status) | grep -q 'nothing to commit, working tree clean'; then
+    printf 'Error: shared Dolt checkout is not clean.\n' >&2
+    exit 1
+fi
+(cd "$SHARED_DOLT_CHECKOUT" && dolt fetch origin master)
 
-[ ! -d "${DOLT_DIR}/investment_data" ] && cd "${DOLT_DIR}" && dolt clone chenditc/investment_data
-[ ! -d "${QLIB_REPO_DIR}" ] && git clone "${QLIB_REPO}" "${QLIB_REPO_DIR}"
+if [[ "$PUBLISHABLE" == true ]]; then
+    SELECTED_DOLT_COMMIT="$BUILD_DOLT_COMMIT"
+else
+    SELECTED_DOLT_COMMIT="$(cd "$SHARED_DOLT_CHECKOUT" \
+        && dolt sql -r csv -q "SELECT DOLT_HASHOF('origin/master') AS value" \
+        | tail -n 1 | tr -d '\r')"
+fi
+if [[ ! "$SELECTED_DOLT_COMMIT" =~ ^[0-9a-v]{32}$ ]]; then
+    printf 'Error: unable to select an immutable Dolt commit.\n' >&2
+    exit 1
+fi
 
-cd "${DOLT_DIR}/investment_data"
-log_step "Fetching latest Dolt data"
-dolt fetch origin master
-dolt reset --hard origin/master
-dolt sql-server &
-DOLT_SQL_SERVER_PID="$!"
+BUILD_ROOT="$(mktemp -d "${WORKING_ROOT%/}/.qlib-build.XXXXXXXX")"
+PRIVATE_DOLT_CHECKOUT="$BUILD_ROOT/dolt/investment_data"
+mkdir -p "$(dirname "$PRIVATE_DOLT_CHECKOUT")"
+cp -a "$SHARED_DOLT_CHECKOUT" "$PRIVATE_DOLT_CHECKOUT"
+flock -u 8
+exec 8>&-
 
-# wait for sql server start
-sleep 5s
+(cd "$PRIVATE_DOLT_CHECKOUT" && dolt checkout -b qlib-build-snapshot "$SELECTED_DOLT_COMMIT")
+PRIVATE_DOLT_COMMIT="$(cd "$PRIVATE_DOLT_CHECKOUT" \
+    && dolt sql -r csv -q "SELECT DOLT_HASHOF('HEAD') AS value" \
+    | tail -n 1 | tr -d '\r')"
+if [[ "$PRIVATE_DOLT_COMMIT" != "$SELECTED_DOLT_COMMIT" ]]; then
+    printf 'Error: private Dolt checkout identity mismatch.\n' >&2
+    exit 1
+fi
 
-cd "${INVESTMENT_DATA_DIR}"
-rm -rf "${BUILD_ROOT}"
-mkdir -p "${QLIB_SOURCE_DIR}" "${QLIB_NORMALIZE_DIR}" "${QLIB_INDEX_DIR}" "${QLIB_BIN_DIR}"
-log_step "Dumping Dolt data to qlib source CSVs"
-QLIB_SOURCE_DIR="${QLIB_SOURCE_DIR}" python3 ./qlib/dump_all_to_qlib_source.py
+if [[ ! -d "$QLIB_REPO_DIR/.git" ]]; then
+    git clone "$QLIB_REPOSITORY" "$QLIB_REPO_DIR"
+fi
+git -C "$QLIB_REPO_DIR" fetch "$QLIB_REPOSITORY" "$QLIB_COMMIT"
+if [[ "$(git -C "$QLIB_REPO_DIR" rev-parse FETCH_HEAD)" != "$QLIB_COMMIT" ]]; then
+    printf 'Error: supplied qlib repository did not fetch the pinned commit.\n' >&2
+    exit 1
+fi
+git -C "$QLIB_REPO_DIR" checkout --detach FETCH_HEAD
+if [[ "$(git -C "$QLIB_REPO_DIR" rev-parse HEAD)" != "$QLIB_COMMIT" ]]; then
+    printf 'Error: qlib checkout identity mismatch.\n' >&2
+    exit 1
+fi
 
-export PYTHONPATH="${PYTHONPATH:-}:${QLIB_REPO_DIR}/scripts"
-cd ./qlib
-log_step "Normalizing qlib data with ${DUMP_QLIB_MAX_WORKERS} workers"
-python3 ./normalize.py normalize_data --source_dir "${QLIB_SOURCE_DIR}/" --normalize_dir "${QLIB_NORMALIZE_DIR}" --max_workers="${DUMP_QLIB_MAX_WORKERS}" --date_field_name="tradedate"
+INVESTMENT_DATA_COMMIT="$(git -C "$INVESTMENT_DATA_DIR" rev-parse HEAD)"
+if [[ "$PUBLISHABLE" == true && "$INVESTMENT_DATA_COMMIT" != "$BUILD_INVESTMENT_DATA_COMMIT" ]]; then
+    printf 'Error: repository checkout does not match publication authority.\n' >&2
+    exit 1
+fi
+
+if [[ "$PUBLISHABLE" == true ]]; then
+    RELEASE_TAG="$BUILD_RELEASE_TAG"
+    IMAGE_DIGEST_JSON="\"$BUILD_IMAGE_DIGEST\""
+else
+    RELEASE_TAG="$(TZ=Asia/Shanghai date +%F)"
+    IMAGE_DIGEST_JSON="null"
+fi
+if ! canonical_date "$RELEASE_TAG"; then
+    printf 'Error: release tag is not canonical.\n' >&2
+    exit 1
+fi
+
+cd "$PRIVATE_DOLT_CHECKOUT"
+dolt sql-server --host 127.0.0.1 --port 3306 >"$BUILD_ROOT/dolt-sql-server.log" 2>&1 &
+DOLT_SQL_SERVER_PID=$!
+
+query_scalar() {
+    DOLT_QUERY="$1" python3 - <<'PY'
+import os
+import pymysql
+
+connection = pymysql.connect(
+    host="127.0.0.1",
+    port=3306,
+    user="root",
+    password="",
+    database="investment_data",
+    connect_timeout=2,
+)
+try:
+    with connection.cursor() as cursor:
+        cursor.execute(os.environ["DOLT_QUERY"])
+        row = cursor.fetchone()
+    print("" if row is None or row[0] is None else row[0])
+finally:
+    connection.close()
+PY
+}
+
+SQL_SERVER_READY=false
+for _ in {1..60}; do
+    if [[ "$(query_scalar "SELECT 1" 2>/dev/null || true)" == "1" ]]; then
+        SQL_SERVER_READY=true
+        break
+    fi
+    kill -0 "$DOLT_SQL_SERVER_PID" 2>/dev/null || break
+    sleep 1
+done
+if [[ "$SQL_SERVER_READY" != true ]] || ! kill -0 "$DOLT_SQL_SERVER_PID" 2>/dev/null; then
+    printf 'Error: Dolt SQL server did not become ready.\n' >&2
+    exit 1
+fi
+SERVER_DOLT_COMMIT="$(query_scalar "SELECT DOLT_HASHOF('HEAD')")"
+if [[ "$SERVER_DOLT_COMMIT" != "$SELECTED_DOLT_COMMIT" ]]; then
+    printf 'Error: Dolt SQL server identity mismatch before generation.\n' >&2
+    exit 1
+fi
+
+TARGET_TRADE_DATE="$(query_scalar "SELECT MAX(date) AS value FROM ts_trade_day_calendar WHERE exchange = 'SSE' AND is_open = 1 AND date <= '$RELEASE_TAG'")"
+SOURCE_MAX_DATE="$(query_scalar "SELECT MAX(tradedate) AS value FROM final_a_stock_eod_price")"
+FUTURE_START_DATE="$(query_scalar "SELECT MIN(date) AS value FROM ts_trade_day_calendar WHERE exchange = 'SSE' AND is_open = 1 AND date > '$TARGET_TRADE_DATE'")"
+FUTURE_END_DATE="$(query_scalar "SELECT MAX(date) AS value FROM ts_trade_day_calendar WHERE exchange = 'SSE' AND is_open = 1")"
+for value in "$TARGET_TRADE_DATE" "$SOURCE_MAX_DATE" "$FUTURE_START_DATE" "$FUTURE_END_DATE"; do
+    if ! canonical_date "$value"; then
+        printf 'Error: snapshot date derivation returned an invalid date.\n' >&2
+        exit 1
+    fi
+done
+if [[ "$SOURCE_MAX_DATE" != "$TARGET_TRADE_DATE" ]]; then
+    printf 'Error: source max date %s does not equal target trade date %s.\n' \
+        "$SOURCE_MAX_DATE" "$TARGET_TRADE_DATE" >&2
+    exit 1
+fi
+if [[ "$RELEASE_TAG" == "2026-07-20" && "$SELECTED_DOLT_COMMIT" == "9vtplc2tar9ver7p6s1bus2oiedjvtqo" ]]; then
+    if [[ "$TARGET_TRADE_DATE/$FUTURE_START_DATE/$FUTURE_END_DATE" != "2026-07-20/2026-07-21/2026-12-31" ]]; then
+        printf 'Error: fixed repair snapshot dates do not match their captured identity.\n' >&2
+        exit 1
+    fi
+fi
+
+QLIB_SOURCE_DIR="$BUILD_ROOT/qlib_source"
+QLIB_NORMALIZE_DIR="$BUILD_ROOT/qlib_normalize"
+QLIB_INDEX_DIR="$BUILD_ROOT/qlib_index"
+QLIB_BIN_DIR="$BUILD_ROOT/qlib_bin"
+mkdir -p "$QLIB_SOURCE_DIR" "$QLIB_NORMALIZE_DIR" "$QLIB_INDEX_DIR" "$QLIB_BIN_DIR"
+
+cd "$INVESTMENT_DATA_DIR"
+log_step "Dumping immutable Dolt data to qlib source CSVs"
+QLIB_SOURCE_DIR="$QLIB_SOURCE_DIR" python3 ./qlib/dump_all_to_qlib_source.py
+QLIB_SOURCE_DIR="$QLIB_SOURCE_DIR" python3 - <<'PY'
+import csv
+import os
+from pathlib import Path
+
+root = Path(os.environ["QLIB_SOURCE_DIR"])
+for path in sorted(root.glob("*.csv"), key=lambda value: value.as_posix()):
+    with path.open(newline="", encoding="utf-8") as stream:
+        reader = csv.DictReader(stream)
+        fieldnames = reader.fieldnames
+        rows = list(reader)
+    if not fieldnames or "tradedate" not in fieldnames:
+        raise ValueError(f"missing tradedate column: {path}")
+    rows.sort(key=lambda row: row["tradedate"])
+    with path.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=fieldnames, lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+PY
+
+export PYTHONPATH="${PYTHONPATH:-}:$QLIB_REPO_DIR:$QLIB_REPO_DIR/scripts"
+log_step "Normalizing qlib data with $DUMP_QLIB_MAX_WORKERS workers"
+python3 ./qlib/normalize.py \
+    --source_dir "$QLIB_SOURCE_DIR" \
+    --normalize_dir "$QLIB_NORMALIZE_DIR" \
+    --max_workers "$DUMP_QLIB_MAX_WORKERS" \
+    --date_field_name tradedate \
+    --target_trade_date "$TARGET_TRADE_DATE"
+
 log_step "Dumping normalized qlib data to binary files"
-dump_bin_help="$(python3 "${QLIB_REPO_DIR}/scripts/dump_bin.py" dump_all --help 2>&1 || true)"
-dump_bin_data_flag="--csv_path"
-if printf '%s' "${dump_bin_help}" | grep -q -- '--data_path'; then
-    dump_bin_data_flag="--data_path"
+python3 "$QLIB_REPO_DIR/scripts/dump_bin.py" dump_all \
+    --data_path "$QLIB_NORMALIZE_DIR" \
+    --qlib_dir "$QLIB_BIN_DIR" \
+    --date_field_name tradedate \
+    --exclude_fields tradedate,symbol
+
+log_step "Dumping bounded qlib index constituents"
+QLIB_INDEX_DIR="$QLIB_INDEX_DIR" python3 ./qlib/dump_index_weight.py \
+    --target_trade_date "$TARGET_TRADE_DATE"
+cp "$QLIB_INDEX_DIR"/csi*.txt "$QLIB_BIN_DIR/instruments/"
+
+log_step "Dumping snapshot future trade calendar"
+python3 ./tushare/dump_day_calendar.py "$QLIB_BIN_DIR" \
+    --target_trade_date "$TARGET_TRADE_DATE"
+
+SERVER_DOLT_COMMIT="$(query_scalar "SELECT DOLT_HASHOF('HEAD')")"
+if [[ "$SERVER_DOLT_COMMIT" != "$SELECTED_DOLT_COMMIT" ]]; then
+    printf 'Error: Dolt SQL server identity mismatch after generation.\n' >&2
+    exit 1
 fi
-python3 "${QLIB_REPO_DIR}/scripts/dump_bin.py" dump_all "${dump_bin_data_flag}=${QLIB_NORMALIZE_DIR}/" --qlib_dir "${QLIB_BIN_DIR}" --date_field_name=tradedate --exclude_fields=tradedate,symbol
-
-mkdir -p "${QLIB_INDEX_DIR}"
-log_step "Dumping qlib index constituents"
-QLIB_INDEX_DIR="${QLIB_INDEX_DIR}" python3 ./dump_index_weight.py
-
-cd "${INVESTMENT_DATA_DIR}"
-log_step "Dumping qlib trade calendar"
-python3 ./tushare/dump_day_calendar.py "${QLIB_BIN_DIR}/"
-
-if [ "${CHECK_FRESHNESS:-0}" = "1" ]; then
-    cd "${DOLT_DIR}/investment_data"
-    source_max_date=$(dolt sql -r csv -q "SELECT MAX(tradedate) AS max_date FROM final_a_stock_eod_price" | tail -n 1)
-    expected_max_date=$(dolt sql -r csv -q "SELECT MAX(date) AS max_date FROM ts_trade_day_calendar WHERE exchange = 'SSE' AND is_open = 1 AND date <= CURRENT_DATE" | tail -n 1)
-    qlib_max_date=$(tail -n 1 "${QLIB_BIN_DIR}/calendars/day.txt")
-
-    echo "Expected latest trade date: ${expected_max_date}"
-    echo "Dolt source latest trade date: ${source_max_date}"
-    echo "Qlib archive latest trade date: ${qlib_max_date}"
-
-    if [ "$source_max_date" != "$expected_max_date" ]; then
-        echo "Dolt source data is stale; refusing to publish release." >&2
-        exit 1
-    fi
-
-    if [ "$qlib_max_date" != "$source_max_date" ]; then
-        echo "Qlib archive is stale; refusing to publish release." >&2
-        exit 1
-    fi
-    cd "${INVESTMENT_DATA_DIR}"
-fi
-
-kill "${DOLT_SQL_SERVER_PID}" >/dev/null 2>&1 || true
-wait "${DOLT_SQL_SERVER_PID}" >/dev/null 2>&1 || true
+kill "$DOLT_SQL_SERVER_PID"
+wait "$DOLT_SQL_SERVER_PID"
 DOLT_SQL_SERVER_PID=""
 
-cp "${QLIB_INDEX_DIR}"/csi* "${QLIB_BIN_DIR}/instruments/"
-
-log_step "Creating qlib_bin.tar.gz"
-tar -czvf ./qlib_bin.tar.gz -C "${BUILD_ROOT}" qlib_bin/
-ls -lh ./qlib_bin.tar.gz
-OUTPUT_DIR=${OUTPUT_DIR:-/output}
-if [ -d "${OUTPUT_DIR}" ]; then
-    mv ./qlib_bin.tar.gz "${OUTPUT_DIR}/"
-    ls -lh "${OUTPUT_DIR}/qlib_bin.tar.gz"
-else
-    echo "Generated tarball at $(pwd)/qlib_bin.tar.gz"
+SOURCE_DATE_EPOCH="$(date -u -d "$RELEASE_TAG 00:00:00Z" +%s)"
+export LC_ALL=C TZ=UTC SOURCE_DATE_EPOCH
+while IFS= read -r -d '' path; do chmod 0755 "$path"; done \
+    < <(find "$QLIB_BIN_DIR" -type d -print0 | sort -z)
+while IFS= read -r -d '' path; do chmod 0644 "$path"; done \
+    < <(find "$QLIB_BIN_DIR" -type f -print0 | sort -z)
+while IFS= read -r -d '' path; do touch -d "@$SOURCE_DATE_EPOCH" "$path"; done \
+    < <(find "$QLIB_BIN_DIR" -type d -print0 | sort -z)
+while IFS= read -r -d '' path; do touch -d "@$SOURCE_DATE_EPOCH" "$path"; done \
+    < <(find "$QLIB_BIN_DIR" -type f -print0 | sort -z)
+if find "$QLIB_BIN_DIR" ! -type d ! -type f -print -quit | grep -q .; then
+    printf 'Error: qlib_bin contains a non-regular filesystem entry.\n' >&2
+    exit 1
 fi
+
+ARCHIVE_PATH="$BUILD_ROOT/qlib_bin.tar.gz"
+MANIFEST_PATH="$BUILD_ROOT/qlib_bin.manifest.json"
+log_step "Creating deterministic qlib archive"
+tar --sort=name --format=ustar --mtime="@$SOURCE_DATE_EPOCH" \
+    --owner=0 --group=0 --numeric-owner -cf - -C "$BUILD_ROOT" qlib_bin \
+    | gzip -n -9 >"$ARCHIVE_PATH"
+ARCHIVE_SIZE="$(stat -c%s "$ARCHIVE_PATH")"
+ARCHIVE_SHA256="sha256:$(sha256sum "$ARCHIVE_PATH" | awk '{print $1}')"
+
+RELEASE_TAG="$RELEASE_TAG" \
+TARGET_TRADE_DATE="$TARGET_TRADE_DATE" \
+FUTURE_START_DATE="$FUTURE_START_DATE" \
+FUTURE_END_DATE="$FUTURE_END_DATE" \
+SELECTED_DOLT_COMMIT="$SELECTED_DOLT_COMMIT" \
+INVESTMENT_DATA_COMMIT="$INVESTMENT_DATA_COMMIT" \
+QLIB_COMMIT="$QLIB_COMMIT" \
+IMAGE_DIGEST_JSON="$IMAGE_DIGEST_JSON" \
+ARCHIVE_SIZE="$ARCHIVE_SIZE" \
+ARCHIVE_SHA256="$ARCHIVE_SHA256" \
+MANIFEST_PATH="$MANIFEST_PATH" \
+python3 - <<'PY'
+import json
+import os
+
+manifest = {
+    "release_tag": os.environ["RELEASE_TAG"],
+    "target_trade_date": os.environ["TARGET_TRADE_DATE"],
+    "future_start_date": os.environ["FUTURE_START_DATE"],
+    "future_end_date": os.environ["FUTURE_END_DATE"],
+    "dolt_commit": os.environ["SELECTED_DOLT_COMMIT"],
+    "investment_data_commit": os.environ["INVESTMENT_DATA_COMMIT"],
+    "qlib_commit": os.environ["QLIB_COMMIT"],
+    "image_digest": json.loads(os.environ["IMAGE_DIGEST_JSON"]),
+    "archive_size_bytes": int(os.environ["ARCHIVE_SIZE"]),
+    "archive_sha256": os.environ["ARCHIVE_SHA256"],
+}
+with open(os.environ["MANIFEST_PATH"], "w", encoding="utf-8", newline="\n") as stream:
+    json.dump(manifest, stream, ensure_ascii=False, separators=(",", ":"))
+    stream.write("\n")
+PY
+
+validator_args=(
+    --archive "$ARCHIVE_PATH"
+    --manifest "$MANIFEST_PATH"
+    --expected-tag "$RELEASE_TAG"
+)
+if [[ "$PUBLISHABLE" == true ]]; then
+    validator_args+=(--require-publishable)
+fi
+python3 "$INVESTMENT_DATA_DIR/qlib/validate_archive.py" "${validator_args[@]}"
+
+if [[ -v OUTPUT_DIR ]]; then
+    DESTINATION_DIR="$OUTPUT_DIR"
+elif [[ -d /output ]]; then
+    DESTINATION_DIR=/output
+else
+    DESTINATION_DIR="$INVESTMENT_DATA_DIR"
+fi
+mv "$ARCHIVE_PATH" "$DESTINATION_DIR/qlib_bin.tar.gz"
+mv "$MANIFEST_PATH" "$DESTINATION_DIR/qlib_bin.manifest.json"
+printf 'Generated validated archive pair at %s\n' "$DESTINATION_DIR"

--- a/ops/investment-data-project-monitor/SKILL.md
+++ b/ops/investment-data-project-monitor/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: investment-data-project-monitor
+description: Monitor and safely repair the chenditc/investment_data GitHub Actions pipeline running on the nvdev2 ARC/minikube runner. Use for on-demand nightly health checks, missing daily data, missing qlib releases, ARC health, or investment_data workflow failures.
+---
+
+# Investment Data Project Monitor
+
+Run this on demand, preferably after 21:00 Asia/Shanghai when checking the completed daily pipeline. Verify the immutable data source first, then the GitHub Actions jobs and the downloaded archive/manifest pair. Perform only the explicitly allowed low-risk repairs. Notify via Feishu when the state is abnormal, ambiguous, or needs a risky action.
+
+## Current Architecture
+
+- GitHub repository: `chenditc/investment_data`, default branch `main`
+- DoltHub repository: `chenditc/investment_data`, branch `master`
+- Data table: `final_a_stock_eod_price`
+- Trading calendar: `ts_trade_day_calendar`
+- Data workflow: `data_update.yml`
+- Release workflow: `upload_release.yml`, scheduled at 11:01 UTC / 19:01 Asia/Shanghai
+- Canonical release pair: `qlib_bin.tar.gz` and `qlib_bin.manifest.json`
+- Runner host: `nvdev2`
+- Minikube profile: `investment-gha`
+- ARC controller namespace: `arc-systems`
+- ARC runner namespace: `arc-runners`
+- Runner scale set: `investment-arc`
+- Docker graph cache PVC: `investment-data-docker-graph`, expected capacity `100Gi`
+
+The old serv1 runner, `upload-qlib-tar` container, host cron, archive path, and proxy are retired. Never use the old repair commands from serv1.
+
+## Safety Rules
+
+- Never print or inspect secret values, environment dumps, Kubernetes Secrets, or container environments.
+- Never delete or recreate a release, tag, PVC, PV, Docker volume, minikube profile, or ARC installation automatically.
+- Never publish a release unless Dolt `max_date` equals the expected SSE trade date.
+- Never perform a direct release upload. Publication authority belongs only to `upload_release.yml` on `main`.
+- Never restart minikube, ARC controller, or listener automatically. Report and notify first.
+- Do not rerun a successful workflow merely because a later artifact was intentionally removed.
+- Trigger each workflow at most once per monitor run, then wait for and verify its result.
+- Prefer observation over repair before 18:30 for data freshness and before 21:00 for release publication.
+
+## Check Sequence
+
+1. Run the collector:
+
+```bash
+bash ~/.claude/skills/investment-data-project-monitor/scripts/collect_health.sh
+```
+
+The collector downloads both canonical assets on every run, verifies their GitHub API size and SHA-256 identities, and runs the deployed byte-identical archive validator. A complete `healthy`, `degraded`, or `not_due` report exits `0`; an inability to construct a report exits nonzero with empty stdout.
+
+2. Read its JSON report. Required healthy state after 21:00 Asia/Shanghai:
+
+- `dolt.data_fresh` is `true`.
+- `platform.healthy` is `true`.
+- The latest `main` data workflow is successful.
+- The latest `main` upload workflow is successful.
+- `release.valid` is `true` for today's tag.
+- Exactly one total uploaded asset exists for each canonical name.
+- `release.archive_validation.ok` is `true`; the object is the validator's unmodified JSON document.
+- No workflow has been in progress for more than 90 minutes.
+
+The reported asset size alone is not evidence of validity. A missing, duplicate, wrong-state, digest-mismatched, stale, malformed, or unsafe archive pair makes the release invalid and, after the due time, degrades overall health.
+
+3. If a workflow failed, inspect only the failed run and its failed job logs:
+
+```bash
+gh run view RUN_ID --repo chenditc/investment_data --json status,conclusion,jobs,url
+gh run view RUN_ID --repo chenditc/investment_data --log-failed
+```
+
+Summarize the error. Do not include secrets or long logs in the report or notification.
+
+## Allowed Repairs
+
+### Stale data after 18:30
+
+Trigger `data_update.yml` only when Dolt is stale, no update is queued/running, the latest scheduled `main` update failed/cancelled/is absent, and this monitor run has not already triggered it:
+
+```bash
+gh workflow run data_update.yml --repo chenditc/investment_data --ref main
+```
+
+Wait for completion, then rerun the collector.
+
+### Missing or invalid release after 21:00
+
+Trigger `upload_release.yml` only when Dolt is fresh, no upload is queued/running, today's canonical pair is invalid, the scheduled `main` upload failed/cancelled/did not run, and this monitor run has not already triggered it:
+
+```bash
+gh workflow run upload_release.yml --repo chenditc/investment_data --ref main -f operation=publish
+```
+
+Wait for completion, then rerun the collector. If the workflow succeeds but the downloaded pair remains invalid, notify instead of attempting direct upload.
+
+## Feishu Notification
+
+Send a notification for any degraded state after its due time, any repair attempt, repeated failure, stuck workflow, low disk space, or action requiring human judgment:
+
+```bash
+~/.claude/skills/investment-data-project-monitor/scripts/notify_feishu.sh "investment_data nightly monitor
+当前时间: ...
+状态: ...
+expected trade date: ...
+Dolt max_date: ...
+data_update: ...
+upload_release: ...
+release archive validation: ...
+ARC/minikube: ...
+已执行的安全修复: ...
+建议人工动作: ..."
+```
+
+The helper, its recipient, arguments, secret lookup, retry timing, and message behavior are unchanged. Do not send a normal-success notification. Never include secrets, environment dumps, or long logs.
+
+### Fail-safe repository rollback
+
+A full repository revert is ordered and fail-closed:
+
+1. Run `gh workflow disable upload_release.yml --repo chenditc/investment_data`.
+2. Query `gh workflow view upload_release.yml --repo chenditc/investment_data --json state --jq .state` and require the exact result `disabled_manually`.
+3. Query both `upload_release.yml` and `data_update.yml` runs and wait until every queued or in-progress job using the shared Dolt volume has drained.
+4. Perform the full repository revert.
+5. Run `gh workflow view upload_release.yml --repo chenditc/investment_data --json state --jq .state` again and require `disabled_manually`.
+6. Do not re-enable publication until validator-backed digest pinning, workflow authority, and shared concurrency/filesystem locking are restored and verified end to end.
+
+The revert may move the convenience `latest` image and therefore affect data update, but it cannot publish while the upload workflow is disabled. Draining is mandatory because a full revert may remove the shared lock and concurrency group. Already accepted release assets are untouched. An interrupted historical repair may complete only through the fixed `repair-2026-07-20` operation, and the stale backup is never auto-restored. The deployed monitor is separate external state; roll it back only with the tracked `ops/investment-data-project-monitor/deploy.sh rollback`, never as part of the repository revert.
+
+
+## Final Report
+
+Report the Asia/Shanghai time and overall state; expected and actual Dolt dates; workflow states and URLs; canonical asset identities and `release.archive_validation`; ARC/minikube/PVC/disk health; stuck runs; repairs and post-repair verification; Feishu outcome; and remaining human action.
+
+Principle: validate the actual release bytes against immutable provenance before declaring publication healthy.

--- a/ops/investment-data-project-monitor/collect_health.sh
+++ b/ops/investment-data-project-monitor/collect_health.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+if (($# != 0)); then
+  printf 'usage: %s\n' "${0##*/}" >&2
+  exit 2
+fi
+
+export PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+for command in jq gh curl minikube sha256sum stat mktemp python3; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    printf 'Required command is unavailable: %s\n' "$command" >&2
+    exit 1
+  fi
+done
+if [[ ! -r "$script_dir/validate_archive.py" ]]; then
+  printf 'Archive validator is unavailable.\n' >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d /tmp/investment-data-health.XXXXXXXX)" || {
+  printf 'Unable to create collector temporary directory.\n' >&2
+  exit 1
+}
+trap 'rm -rf -- "$tmp_dir"' EXIT
+
+set -a
+if [[ -f "$HOME/.secret_env" ]]; then
+  # shellcheck disable=SC1091
+  source "$HOME/.secret_env"
+fi
+if [[ -f "$HOME/.amc/.env" ]]; then
+  # Compatibility with the existing nvdev2 secret store.
+  # shellcheck disable=SC1091
+  source "$HOME/.amc/.env"
+fi
+set +a
+export GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+
+repo="chenditc/investment_data"
+profile="investment-gha"
+today="$(TZ=Asia/Shanghai date +%F)"
+now="$(TZ=Asia/Shanghai date '+%Y-%m-%d %H:%M:%S %Z %z')"
+time_hhmm="$(TZ=Asia/Shanghai date +%H%M)"
+
+error_json() {
+  jq -cn --arg error "$1" '{error:$error}'
+}
+
+dolt_query() {
+  local query="$1"
+  local output
+  if output="$(curl -fsS --get --data-urlencode "q=$query" \
+      "https://www.dolthub.com/api/v1alpha1/chenditc/investment_data/master" 2>&1)"; then
+    printf '%s' "$output"
+  else
+    error_json "$output"
+  fi
+}
+
+dolt_max_raw="$(dolt_query 'SELECT MAX(tradedate) AS max_date FROM final_a_stock_eod_price')"
+expected_raw="$(dolt_query "SELECT MAX(date) AS expected_date FROM ts_trade_day_calendar WHERE exchange = 'SSE' AND is_open = 1 AND date <= CURRENT_DATE")"
+dolt_max="$(jq -r '.rows[0].max_date // empty' <<<"$dolt_max_raw" 2>/dev/null)"
+expected_date="$(jq -r '.rows[0].expected_date // empty' <<<"$expected_raw" 2>/dev/null)"
+
+data_fresh=false
+if [[ -n "$dolt_max" && "$dolt_max" == "$expected_date" ]]; then
+  data_fresh=true
+fi
+
+minikube_raw="$(minikube status -p "$profile" --output=json 2>&1)"
+if ! jq -e . >/dev/null 2>&1 <<<"$minikube_raw"; then
+  minikube_raw="$(error_json "$minikube_raw")"
+fi
+
+nodes_raw="$(minikube -p "$profile" kubectl -- get nodes -o json 2>&1)"
+if jq -e . >/dev/null 2>&1 <<<"$nodes_raw"; then
+  nodes="$(jq -c '[.items[] | {name:.metadata.name,ready:any(.status.conditions[]?; .type == "Ready" and .status == "True"),kernel:(.status.nodeInfo.kernelVersion // null),containerRuntime:(.status.nodeInfo.containerRuntimeVersion // null)}]' <<<"$nodes_raw")"
+else
+  nodes="$(error_json "$nodes_raw")"
+fi
+
+pods_raw="$(minikube -p "$profile" kubectl -- get pods --all-namespaces -o json 2>&1)"
+if jq -e . >/dev/null 2>&1 <<<"$pods_raw"; then
+  pods="$(jq -c '[.items[] | select(.metadata.namespace == "arc-systems" or .metadata.namespace == "arc-runners") | {namespace:.metadata.namespace,name:.metadata.name,phase:.status.phase,ready:([.status.containerStatuses[]? | .ready] | all),restarts:([.status.containerStatuses[]?.restartCount] | add // 0),startedAt:(.status.startTime // null)}]' <<<"$pods_raw")"
+else
+  pods="$(error_json "$pods_raw")"
+fi
+
+scale_set_raw="$(minikube -p "$profile" kubectl -- get autoscalingrunnerset investment-arc -n arc-runners -o json 2>&1)"
+if jq -e . >/dev/null 2>&1 <<<"$scale_set_raw"; then
+  scale_set="$(jq -c '{name:.metadata.name,minRunners:(.spec.minRunners // null),maxRunners:(.spec.maxRunners // null),currentRunners:(.status.currentRunners // 0),pendingRunners:(.status.pendingRunners // 0),runningRunners:(.status.runningRunners // 0)}' <<<"$scale_set_raw")"
+else
+  scale_set="$(error_json "$scale_set_raw")"
+fi
+
+pvc_raw="$(minikube -p "$profile" kubectl -- get pvc investment-data-docker-graph -n arc-runners -o json 2>&1)"
+if jq -e . >/dev/null 2>&1 <<<"$pvc_raw"; then
+  pvc="$(jq -c '{name:.metadata.name,phase:.status.phase,capacity:(.status.capacity.storage // null),storageClass:(.spec.storageClassName // null)}' <<<"$pvc_raw")"
+else
+  pvc="$(error_json "$pvc_raw")"
+fi
+
+platform_healthy="$(jq -rn \
+  --argjson nodes "$nodes" \
+  --argjson pods "$pods" \
+  --argjson scale_set "$scale_set" \
+  --argjson pvc "$pvc" '
+    (($nodes | type) == "array")
+    and (($nodes | length) > 0)
+    and ([$nodes[] | select(.ready != true)] | length == 0)
+    and (($pods | type) == "array")
+    and ([$pods[] | select(.namespace == "arc-systems" and (.name | contains("controller")))] | length == 1)
+    and ([$pods[] | select(.namespace == "arc-systems" and (.name | contains("listener")))] | length == 1)
+    and ([$pods[] | select(.phase != "Running" or .ready != true)] | length == 0)
+    and ($scale_set.name == "investment-arc")
+    and ($pvc.phase == "Bound")')"
+
+data_runs="$(gh run list --repo "$repo" --workflow data_update.yml --limit 10 \
+  --json databaseId,status,conclusion,createdAt,updatedAt,url,headBranch,event 2>&1)"
+if ! jq -e . >/dev/null 2>&1 <<<"$data_runs"; then
+  data_runs="$(error_json "$data_runs")"
+fi
+
+upload_runs="$(gh run list --repo "$repo" --workflow upload_release.yml --limit 10 \
+  --json databaseId,status,conclusion,createdAt,updatedAt,url,headBranch,event 2>&1)"
+if ! jq -e . >/dev/null 2>&1 <<<"$upload_runs"; then
+  upload_runs="$(error_json "$upload_runs")"
+fi
+
+latest_main_data="$(jq -cn --argjson runs "$data_runs" '
+  if ($runs | type) == "array" then ([ $runs[] | select(.headBranch == "main") ][0] // null) else null end')"
+latest_main_upload="$(jq -cn --argjson runs "$upload_runs" '
+  if ($runs | type) == "array" then ([ $runs[] | select(.headBranch == "main") ][0] // null) else null end')"
+now_epoch="$(date -u +%s)"
+stuck_runs="$(jq -cn \
+  --argjson now "$now_epoch" \
+  --argjson data "$data_runs" \
+  --argjson upload "$upload_runs" '
+    [
+      ((if ($data | type) == "array" then $data else [] end)[]?),
+      ((if ($upload | type) == "array" then $upload else [] end)[]?)
+      | select(.status != "completed")
+      | . + {ageSeconds:($now - (.createdAt | fromdateiso8601))}
+      | select(.ageSeconds > 5400)
+    ]')"
+
+release_output="$(gh release view "$today" --repo "$repo" \
+  --json tagName,isDraft,isPrerelease,publishedAt,url,assets 2>&1)"
+if jq -e . >/dev/null 2>&1 <<<"$release_output"; then
+  release="$(jq -c '. + {exists:true}' <<<"$release_output")"
+else
+  release="$(jq -cn --arg error "$release_output" '{exists:false,error:$error,assets:[]}')"
+fi
+
+archive_validation=null
+archive_error=""
+release_valid=false
+archive_assets="$(jq -c '[.assets[]? | select(.name == "qlib_bin.tar.gz")]' <<<"$release")"
+manifest_assets="$(jq -c '[.assets[]? | select(.name == "qlib_bin.manifest.json")]' <<<"$release")"
+if ! jq -e --arg today "$today" \
+    '.exists == true and .tagName == $today and .isDraft == false and .isPrerelease == false' \
+    >/dev/null 2>&1 <<<"$release"; then
+  archive_error="release identity is invalid"
+elif [[ "$(jq 'length' <<<"$archive_assets")" != "1" \
+    || "$(jq 'length' <<<"$manifest_assets")" != "1" ]]; then
+  archive_error="canonical archive and manifest names must each occur exactly once"
+elif [[ "$(jq -r '.[0].state' <<<"$archive_assets")" != "uploaded" \
+    || "$(jq -r '.[0].state' <<<"$manifest_assets")" != "uploaded" ]]; then
+  archive_error="canonical archive and manifest must both be uploaded"
+else
+  archive_api_url="$(jq -r '.[0].apiUrl' <<<"$archive_assets")"
+  manifest_api_url="$(jq -r '.[0].apiUrl' <<<"$manifest_assets")"
+  archive_identity="$(gh api "$archive_api_url" 2>&1)"
+  manifest_identity="$(gh api "$manifest_api_url" 2>&1)"
+  if ! jq -e --arg url "$archive_api_url" \
+      '.url == $url and .name == "qlib_bin.tar.gz" and .state == "uploaded" and (.size | type == "number") and (.size > 0) and (.digest | test("^sha256:[0-9a-f]{64}$"))' \
+      >/dev/null 2>&1 <<<"$archive_identity"; then
+    archive_error="archive API identity is invalid"
+  elif ! jq -e --arg url "$manifest_api_url" \
+      '.url == $url and .name == "qlib_bin.manifest.json" and .state == "uploaded" and (.size | type == "number") and (.size > 0) and (.digest | test("^sha256:[0-9a-f]{64}$"))' \
+      >/dev/null 2>&1 <<<"$manifest_identity"; then
+    archive_error="manifest API identity is invalid"
+  else
+    archive_path="$tmp_dir/qlib_bin.tar.gz"
+    manifest_path="$tmp_dir/qlib_bin.manifest.json"
+    if ! gh api -H 'Accept: application/octet-stream' "$archive_api_url" >"$archive_path" 2>"$tmp_dir/archive-download.err"; then
+      archive_error="archive download failed"
+    elif ! gh api -H 'Accept: application/octet-stream' "$manifest_api_url" >"$manifest_path" 2>"$tmp_dir/manifest-download.err"; then
+      archive_error="manifest download failed"
+    elif [[ "$(stat -c%s "$archive_path")" != "$(jq -r '.size' <<<"$archive_identity")" \
+        || "sha256:$(sha256sum "$archive_path" | awk '{print $1}')" != "$(jq -r '.digest' <<<"$archive_identity")" ]]; then
+      archive_error="archive download identity mismatch"
+    elif [[ "$(stat -c%s "$manifest_path")" != "$(jq -r '.size' <<<"$manifest_identity")" \
+        || "sha256:$(sha256sum "$manifest_path" | awk '{print $1}')" != "$(jq -r '.digest' <<<"$manifest_identity")" ]]; then
+      archive_error="manifest download identity mismatch"
+    else
+      validator_stdout="$tmp_dir/validator.stdout"
+      validator_stderr="$tmp_dir/validator.stderr"
+      validator_status=0
+      python3 "$script_dir/validate_archive.py" \
+        --archive "$archive_path" --manifest "$manifest_path" \
+        --expected-tag "$today" --require-publishable \
+        >"$validator_stdout" 2>"$validator_stderr" || validator_status=$?
+      if [[ "$validator_status" != "0" && "$validator_status" != "1" ]]; then
+        archive_error="archive validator could not produce a report"
+      elif ! jq -e 'type == "object" and (.ok | type == "boolean")' \
+          >/dev/null 2>&1 "$validator_stdout"; then
+        archive_error="archive validator output is invalid"
+      else
+        archive_validation="$(jq -c . "$validator_stdout")"
+        if [[ "$validator_status" == "0" && "$(jq -r '.ok' <<<"$archive_validation")" == "true" ]]; then
+          release_valid=true
+        fi
+      fi
+    fi
+  fi
+fi
+
+host_disk="$(df -P "$HOME" | awk 'NR==2 {print $5}' | tr -d '%')"
+if [[ ! "$host_disk" =~ ^[0-9]+$ ]]; then
+  host_disk=0
+fi
+
+data_check_due=false
+release_check_due=false
+if ((10#$time_hhmm >= 1830)); then
+  data_check_due=true
+fi
+if ((10#$time_hhmm >= 2100)); then
+  release_check_due=true
+fi
+
+overall="healthy"
+if [[ "$platform_healthy" != "true" ]] || ((host_disk >= 90)); then
+  overall="degraded"
+elif [[ "$data_check_due" == "true" && "$data_fresh" != "true" ]]; then
+  overall="degraded"
+elif [[ "$data_check_due" == "true" && "$(jq -r '.conclusion // empty' <<<"$latest_main_data")" != "success" ]]; then
+  overall="degraded"
+elif [[ "$release_check_due" == "true" && "$release_valid" != "true" ]]; then
+  overall="degraded"
+elif [[ "$release_check_due" == "true" && "$(jq -r '.conclusion // empty' <<<"$latest_main_upload")" != "success" ]]; then
+  overall="degraded"
+elif (("$(jq 'length' <<<"$stuck_runs")" > 0)); then
+  overall="degraded"
+elif [[ "$data_check_due" != "true" || "$release_check_due" != "true" ]]; then
+  overall="not_due"
+fi
+
+report="$(jq -n \
+  --arg now "$now" \
+  --arg today "$today" \
+  --arg overall "$overall" \
+  --arg expected_date "$expected_date" \
+  --arg dolt_max "$dolt_max" \
+  --arg archive_error "$archive_error" \
+  --argjson archive_validation "$archive_validation" \
+  --argjson data_fresh "$data_fresh" \
+  --argjson data_check_due "$data_check_due" \
+  --argjson release_check_due "$release_check_due" \
+  --argjson minikube "$minikube_raw" \
+  --argjson nodes "$nodes" \
+  --argjson platform_healthy "$platform_healthy" \
+  --argjson pods "$pods" \
+  --argjson scale_set "$scale_set" \
+  --argjson pvc "$pvc" \
+  --argjson data_runs "$data_runs" \
+  --argjson upload_runs "$upload_runs" \
+  --argjson latest_main_data "$latest_main_data" \
+  --argjson latest_main_upload "$latest_main_upload" \
+  --argjson stuck_runs "$stuck_runs" \
+  --argjson release "$release" \
+  --argjson release_valid "$release_valid" \
+  --argjson host_disk_percent "$host_disk" \
+  '{
+    checked_at:$now,
+    today:$today,
+    overall_status:$overall,
+    policy:{data_check_due:$data_check_due,release_check_due:$release_check_due},
+    dolt:{expected_date:$expected_date,max_date:$dolt_max,data_fresh:$data_fresh},
+    workflows:{
+      data_update:$data_runs,
+      upload_release:$upload_runs,
+      latest_main_data:$latest_main_data,
+      latest_main_upload:$latest_main_upload,
+      stuck_over_90m:$stuck_runs
+    },
+    release:($release + {
+      valid:$release_valid,
+      archive_validation:$archive_validation,
+      archive_error:(if $archive_error == "" then null else $archive_error end)
+    }),
+    platform:{healthy:$platform_healthy,minikube:$minikube,nodes:$nodes,pods:$pods,scale_set:$scale_set,pvc:$pvc,host_disk_used_percent:$host_disk_percent}
+  }' 2>"$tmp_dir/report.err")" || {
+    printf 'Unable to construct complete health report.\n' >&2
+    exit 1
+  }
+printf '%s\n' "$report"

--- a/ops/investment-data-project-monitor/deploy.sh
+++ b/ops/investment-data-project-monitor/deploy.sh
@@ -1,0 +1,513 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PRODUCTION_TARGET="/localhome/local-dichen/.claude/skills-own/investment-data-project-monitor"
+PRODUCTION_MERGED="/localhome/local-dichen/.claude/skills/investment-data-project-monitor"
+PRODUCTION_ROLLBACK="/localhome/local-dichen/.claude/skills-own/.investment-data-project-monitor.rollback-148"
+COMPATIBILITY_LINK_NAME="investment-data-project-monitor"
+COMPATIBILITY_LINK_TARGET="/localhome/local-dichen/.claude/skills/investment-data-project-monitor"
+AUTHORIZED_OLD_SKILL_SHA256="0ec01463ab825502d6599d8c5f236bd56a9a0b2fdb76156fc5d997c04dbb9bbc"
+AUTHORIZED_OLD_COLLECTOR_SHA256="f2b6d97b18f2f5cf5b902c1a78f5043c1659ada6659ffb7105454dd84e3057b6"
+AUTHORIZED_NOTIFIER_SHA256="bda57d27128637c6dd7139fe8825205c957483400b063c02f48fcf209d294224"
+
+# Tests may override this function only after sourcing the script. The production
+# entrypoint never provides an interruption selector.
+deploy_checkpoint() {
+  :
+}
+
+deploy_error() {
+  printf 'Error: %s\n' "$*" >&2
+  return 1
+}
+
+file_digest() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+file_mode() {
+  stat -c '%a' "$1"
+}
+
+same_file_identity() {
+  [[ -f "$1" && ! -L "$1" && -f "$2" && ! -L "$2" \
+      && "$(file_mode "$1")" == "$(file_mode "$2")" \
+      && "$(file_digest "$1")" == "$(file_digest "$2")" ]]
+}
+
+fixed_inventory() {
+  local root=$1
+  find "$root" -mindepth 1 -printf '%P\n' | LC_ALL=C sort
+}
+
+verify_inventory() {
+  local root=$1 allow_validator=$2 allow_stages=${3:-false}
+  local inventory raw_inventory entry expected compatibility_link
+  [[ -d "$root" && ! -L "$root" ]] \
+    || { deploy_error "skill directory is not physical: $root"; return 1; }
+  raw_inventory="$(fixed_inventory "$root")" || return 1
+  inventory=""
+  while IFS= read -r entry; do
+    if [[ "$allow_stages" == true ]] && [[ "$entry" == "SKILL.md.next" \
+        || "$entry" == "scripts/collect_health.sh.next" \
+        || "$entry" == "scripts/validate_archive.py.next" ]]; then
+      [[ -f "$root/$entry" && ! -L "$root/$entry" ]] \
+        || { deploy_error "fixed staging path has an unexpected type: $root/$entry"; return 1; }
+      continue
+    fi
+    if [[ -z "$inventory" ]]; then
+      inventory=$entry
+    else
+      inventory+=$'\n'$entry
+    fi
+  done <<<"$raw_inventory"
+  expected=$'SKILL.md\ninvestment-data-project-monitor\nscripts\nscripts/collect_health.sh\nscripts/notify_feishu.sh'
+  if [[ "$allow_validator" == true ]]; then
+    expected+=$'\nscripts/validate_archive.py'
+  fi
+  [[ "$inventory" == "$expected" ]] \
+    || { deploy_error "unexpected inventory below $root"; return 1; }
+
+  compatibility_link="$root/$COMPATIBILITY_LINK_NAME"
+  [[ -L "$compatibility_link" ]] \
+    || { deploy_error "authorized compatibility link is absent below $root"; return 1; }
+  [[ "$(readlink "$compatibility_link")" == "$COMPATIBILITY_LINK_TARGET" ]] \
+    || { deploy_error "compatibility link target is invalid below $root"; return 1; }
+
+  [[ -f "$root/SKILL.md" && ! -L "$root/SKILL.md" ]] || return 1
+  [[ -f "$root/scripts/collect_health.sh" && ! -L "$root/scripts/collect_health.sh" ]] \
+    || return 1
+  [[ -f "$root/scripts/notify_feishu.sh" && ! -L "$root/scripts/notify_feishu.sh" ]] \
+    || return 1
+  if [[ "$allow_validator" == true ]]; then
+    [[ -f "$root/scripts/validate_archive.py" && ! -L "$root/scripts/validate_archive.py" ]] \
+      || return 1
+  else
+    [[ ! -e "$root/scripts/validate_archive.py" && ! -L "$root/scripts/validate_archive.py" ]] \
+      || return 1
+  fi
+}
+
+verify_compatibility_link_matches() {
+  local target=$1 backup=$2 target_link backup_link
+  target_link="$target/$COMPATIBILITY_LINK_NAME"
+  backup_link="$backup/$COMPATIBILITY_LINK_NAME"
+  [[ -L "$backup_link" \
+      && "$(readlink "$backup_link")" == "$COMPATIBILITY_LINK_TARGET" \
+      && -L "$target_link" \
+      && "$(readlink "$target_link")" == "$COMPATIBILITY_LINK_TARGET" ]] \
+    || { deploy_error "compatibility link was not preserved"; return 1; }
+}
+
+verify_source_files() {
+  local source_skill=$1 source_collector=$2 source_validator=$3
+  [[ -f "$source_skill" && ! -L "$source_skill" && "$(file_mode "$source_skill")" == 644 ]] \
+    || { deploy_error "repository SKILL.md must be a 0644 regular file"; return 1; }
+  [[ -f "$source_collector" && ! -L "$source_collector" && "$(file_mode "$source_collector")" == 755 ]] \
+    || { deploy_error "repository collector must be a 0755 regular file"; return 1; }
+  [[ -f "$source_validator" && ! -L "$source_validator" && "$(file_mode "$source_validator")" == 755 ]] \
+    || { deploy_error "repository validator must be a 0755 regular file"; return 1; }
+  bash -n "$source_collector" || return 1
+  python3 -c 'compile(open(__import__("sys").argv[1], encoding="utf-8").read(), __import__("sys").argv[1], "exec")' "$source_validator" \
+    || return 1
+  validator_smoke "$source_validator" || return 1
+}
+
+verify_authorized_file() {
+  local path=$1 expected_mode=$2 expected_digest=$3 label=$4
+  [[ -f "$path" && ! -L "$path" ]] \
+    || { deploy_error "$label is not an authorized regular file: $path"; return 1; }
+  [[ "$(file_mode "$path")" == "$expected_mode" ]] \
+    || { deploy_error "$label mode differs from the authorized old file: $path"; return 1; }
+  [[ "$(file_digest "$path")" == "$expected_digest" ]] \
+    || { deploy_error "$label hash differs from the authorized old file: $path"; return 1; }
+}
+
+validator_smoke() {
+  local validator=$1 smoke_dir
+  smoke_dir="$(mktemp -d /tmp/investment-data-validator-smoke.XXXXXXXX)" || return 1
+  if ! python3 - "$validator" "$smoke_dir" <<'PY'
+import datetime
+import hashlib
+import io
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+
+validator = Path(sys.argv[1])
+root = Path(sys.argv[2])
+required = {
+    "qlib_bin/calendars/day.txt": b"2026-07-17\n2026-07-20\n",
+    "qlib_bin/calendars/day_future.txt": b"2026-07-17\n2026-07-20\n2026-07-21\n2026-12-31\n",
+    "qlib_bin/instruments/all.txt": b"sh600000\t2026-07-17\t2026-07-20\n",
+    "qlib_bin/instruments/csi300.txt": b"sh600000\t2026-07-17\t2026-07-20\n",
+    "qlib_bin/instruments/csi500.txt": b"sh600000\t2026-07-17\t2026-07-20\n",
+    "qlib_bin/instruments/csi800.txt": b"sh600000\t2026-07-17\t2026-07-20\n",
+    "qlib_bin/instruments/csi1000.txt": b"sh600000\t2026-07-17\t2026-07-20\n",
+    "qlib_bin/instruments/csiall.txt": b"sh600000\t2026-07-17\t2026-07-20\n",
+}
+
+def make_pair(stem, malformed=False, unsafe=False):
+    archive = root / f"{stem}.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        for name, data in required.items():
+            if malformed and name == "qlib_bin/instruments/csi300.txt":
+                data = b"malformed row\n"
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            info.mtime = 0
+            tar.addfile(info, io.BytesIO(data))
+        if unsafe:
+            info = tarfile.TarInfo("qlib_bin/unsafe-link")
+            info.type = tarfile.SYMTYPE
+            info.linkname = "/etc/passwd"
+            tar.addfile(info)
+    digest = "sha256:" + hashlib.sha256(archive.read_bytes()).hexdigest()
+    manifest = root / f"{stem}.json"
+    payload = {
+        "release_tag": "2026-07-20",
+        "target_trade_date": "2026-07-20",
+        "future_start_date": "2026-07-21",
+        "future_end_date": "2026-12-31",
+        "dolt_commit": "9vtplc2tar9ver7p6s1bus2oiedjvtqo",
+        "investment_data_commit": "0" * 40,
+        "qlib_commit": "b87a2c294d364a33fb739359886acffe8ec907d1",
+        "image_digest": None,
+        "archive_size_bytes": archive.stat().st_size,
+        "archive_sha256": digest,
+    }
+    manifest.write_text(json.dumps(payload, separators=(",", ":")) + "\n", encoding="utf-8")
+    return archive, manifest
+
+good = make_pair("good")
+malformed = make_pair("malformed", malformed=True)
+unsafe = make_pair("unsafe", unsafe=True)
+good_run = subprocess.run(
+    [sys.executable, str(validator), "--archive", str(good[0]), "--manifest", str(good[1]), "--expected-tag", "2026-07-20"],
+    capture_output=True,
+    text=True,
+)
+malformed_run = subprocess.run(
+    [sys.executable, str(validator), "--archive", str(malformed[0]), "--manifest", str(malformed[1]), "--expected-tag", "2026-07-20"],
+    capture_output=True,
+    text=True,
+)
+unsafe_run = subprocess.run(
+    [sys.executable, str(validator), "--archive", str(unsafe[0]), "--manifest", str(unsafe[1]), "--expected-tag", "2026-07-20"],
+    capture_output=True,
+    text=True,
+)
+if good_run.returncode != 0 or json.loads(good_run.stdout).get("ok") is not True:
+    raise SystemExit("good validator fixture failed")
+if malformed_run.returncode != 1 or json.loads(malformed_run.stdout) != {"ok": False, "error": "malformed-required-member"}:
+    raise SystemExit("malformed validator fixture was not rejected")
+if unsafe_run.returncode != 1 or json.loads(unsafe_run.stdout) != {"ok": False, "error": "unsafe-archive-member"}:
+    raise SystemExit("unsafe validator fixture was not rejected")
+PY
+  then
+    rm -rf -- "$smoke_dir"
+    return 1
+  fi
+  rm -rf -- "$smoke_dir"
+}
+
+verify_backup_tree() {
+  local backup=$1
+  [[ -d "$backup" && ! -L "$backup" ]] \
+    || { deploy_error "rollback copy is not a physical directory"; return 1; }
+  verify_inventory "$backup" false || return 1
+  verify_authorized_file "$backup/SKILL.md" 644 "$AUTHORIZED_OLD_SKILL_SHA256" \
+    "rollback SKILL.md" || return 1
+  verify_authorized_file "$backup/scripts/collect_health.sh" 700 \
+    "$AUTHORIZED_OLD_COLLECTOR_SHA256" "rollback collector" || return 1
+  verify_authorized_file "$backup/scripts/notify_feishu.sh" 700 \
+    "$AUTHORIZED_NOTIFIER_SHA256" "rollback notifier" || return 1
+  [[ ! -e "$backup/scripts/validate_archive.py" && ! -L "$backup/scripts/validate_archive.py" ]] \
+    || { deploy_error "authoritative pre-validator rollback tree contains a validator"; return 1; }
+}
+
+prepare_rollback_copy() {
+  local target=$1 rollback=$2 next="${rollback}.next" current_has_validator=false
+  [[ -f "$target/scripts/validate_archive.py" ]] && current_has_validator=true
+  verify_inventory "$target" "$current_has_validator" true || return 1
+
+  if [[ -e "$rollback" ]]; then
+    [[ ! -e "$next" ]] \
+      || { deploy_error "rollback copy and rollback staging path both exist"; return 1; }
+    verify_backup_tree "$rollback" || return 1
+    verify_compatibility_link_matches "$target" "$rollback" || return 1
+    return
+  fi
+  [[ "$current_has_validator" == false ]] \
+    || { deploy_error "initial rollback source unexpectedly contains a validator"; return 1; }
+  verify_authorized_file "$target/SKILL.md" 644 "$AUTHORIZED_OLD_SKILL_SHA256" \
+    "installed old SKILL.md" || return 1
+  verify_authorized_file "$target/scripts/collect_health.sh" 700 \
+    "$AUTHORIZED_OLD_COLLECTOR_SHA256" "installed old collector" || return 1
+  verify_authorized_file "$target/scripts/notify_feishu.sh" 700 \
+    "$AUTHORIZED_NOTIFIER_SHA256" "installed notifier" || return 1
+  if [[ -e "$next" ]]; then
+    [[ -d "$next" && ! -L "$next" ]] \
+      || { deploy_error "rollback staging path has unexpected type"; return 1; }
+    diff -qr "$target" "$next" >/dev/null \
+      || { deploy_error "existing rollback staging copy does not match the physical skill"; return 1; }
+  else
+    cp -a "$target" "$next" || return 1
+    deploy_checkpoint rollback-copy-created || return 1
+  fi
+  diff -qr "$target" "$next" >/dev/null \
+    || { deploy_error "rollback copy verification failed"; return 1; }
+  verify_backup_tree "$next" || return 1
+  verify_compatibility_link_matches "$target" "$next" || return 1
+  deploy_checkpoint rollback-copy-verified || return 1
+  mv "$next" "$rollback" || return 1
+  deploy_checkpoint rollback-copy-promoted || return 1
+  verify_backup_tree "$rollback" || return 1
+  verify_compatibility_link_matches "$target" "$rollback" || return 1
+}
+
+classify_destination() {
+  local destination=$1 source=$2 backup_path=$3
+  if [[ -L "$destination" || ( -e "$destination" && ! -f "$destination" ) ]]; then
+    deploy_error "destination has unexpected type: $destination"
+    return 1
+  fi
+  if [[ -f "$destination" ]] && same_file_identity "$destination" "$source"; then
+    printf 'new\n'
+  elif [[ -f "$backup_path" ]] && [[ -f "$destination" ]] \
+      && same_file_identity "$destination" "$backup_path"; then
+    printf 'old\n'
+  elif [[ ! -e "$backup_path" && ! -e "$destination" ]]; then
+    printf 'old\n'
+  else
+    deploy_error "destination is neither verified old nor verified new: $destination"
+  fi
+}
+
+install_one() {
+  local source=$1 destination=$2 backup_path=$3 label=${4:-file} next state
+  next="${destination}.next"
+  state="$(classify_destination "$destination" "$source" "$backup_path")" || return 1
+  if [[ "$state" == new ]]; then
+    if [[ -e "$next" || -L "$next" ]]; then
+      [[ -f "$next" && ! -L "$next" ]] \
+        || { deploy_error "staging path has unexpected type: $next"; return 1; }
+      rm -f -- "$next" || return 1
+    fi
+    return
+  fi
+  if [[ -e "$next" ]] && ! same_file_identity "$next" "$source"; then
+    [[ -f "$next" && ! -L "$next" ]] \
+      || { deploy_error "staging path has unexpected type: $next"; return 1; }
+    # Old/new destination and rollback identities were verified above.
+    rm -f -- "$next" || return 1
+  fi
+  if [[ ! -e "$next" ]]; then
+    cp -p "$source" "$next" || return 1
+    deploy_checkpoint "$label-staged" || return 1
+  fi
+  same_file_identity "$next" "$source" \
+    || { deploy_error "staged file verification failed: $next"; return 1; }
+  if [[ "$source" == *.sh ]]; then
+    bash -n "$next" || return 1
+  elif [[ "$source" == *.py ]]; then
+    python3 -c 'compile(open(__import__("sys").argv[1], encoding="utf-8").read(), __import__("sys").argv[1], "exec")' "$next" \
+      || return 1
+  fi
+  deploy_checkpoint "$label-verified" || return 1
+  mv "$next" "$destination" || return 1
+  deploy_checkpoint "$label-promoted" || return 1
+  same_file_identity "$destination" "$source" \
+    || { deploy_error "installed file verification failed"; return 1; }
+}
+
+verify_notifier() {
+  local target=$1 rollback=$2
+  verify_authorized_file "$target/scripts/notify_feishu.sh" 700 \
+    "$AUTHORIZED_NOTIFIER_SHA256" "installed notifier" || return 1
+  verify_authorized_file "$rollback/scripts/notify_feishu.sh" 700 \
+    "$AUTHORIZED_NOTIFIER_SHA256" "rollback notifier" || return 1
+  same_file_identity "$target/scripts/notify_feishu.sh" "$rollback/scripts/notify_feishu.sh" \
+    || { deploy_error "notification helper identity changed"; return 1; }
+}
+
+verify_view() {
+  local source_skill=$1 source_collector=$2 source_validator=$3 view=$4
+  same_file_identity "$source_skill" "$view/SKILL.md" || return 1
+  same_file_identity "$source_collector" "$view/scripts/collect_health.sh" || return 1
+  same_file_identity "$source_validator" "$view/scripts/validate_archive.py" || return 1
+}
+
+finish_parked_validator_restore() {
+  local source_validator=$1 target=$2 merged=$3 rollback=$4
+  local parked="$target/scripts/validate_archive.py.next"
+  [[ -e "$parked" ]] || return 0
+
+  [[ -f "$parked" && ! -L "$parked" ]] \
+    || { deploy_error "parked validator has unexpected type"; return 1; }
+  verify_backup_tree "$rollback" || return 1
+  verify_compatibility_link_matches "$target" "$rollback" || return 1
+  [[ ! -e "$rollback/scripts/validate_archive.py" ]] \
+    || { deploy_error "parked-validator recovery requires the pre-validator rollback inventory"; return 1; }
+  same_file_identity "$parked" "$source_validator" \
+    || { deploy_error "parked validator identity is unexpected"; return 1; }
+  same_file_identity "$target/SKILL.md" "$rollback/SKILL.md" || return 1
+  same_file_identity "$target/scripts/collect_health.sh" "$rollback/scripts/collect_health.sh" \
+    || return 1
+  [[ ! -e "$target/scripts/validate_archive.py" ]] || return 1
+  same_file_identity "$merged/SKILL.md" "$rollback/SKILL.md" || return 1
+  same_file_identity "$merged/scripts/collect_health.sh" "$rollback/scripts/collect_health.sh" \
+    || return 1
+  [[ ! -e "$merged/scripts/validate_archive.py" ]] || return 1
+  verify_notifier "$target" "$rollback" || return 1
+  rm -f -- "$parked" || return 1
+  deploy_checkpoint restore-validator-removed || return 1
+  verify_inventory "$target" false || return 1
+  verify_compatibility_link_matches "$target" "$rollback" || return 1
+}
+
+restore_from_rollback() {
+  local target=$1 merged=$2 rollback=$3 parked
+  verify_backup_tree "$rollback" || return 1
+  verify_compatibility_link_matches "$target" "$rollback" || return 1
+  verify_notifier "$target" "$rollback" || return 1
+
+  install_one "$rollback/scripts/collect_health.sh" "$target/scripts/collect_health.sh" \
+    "$target/scripts/collect_health.sh" restore-collector || return 1
+  install_one "$rollback/SKILL.md" "$target/SKILL.md" "$target/SKILL.md" \
+    restore-skill || return 1
+
+  parked="$target/scripts/validate_archive.py.next"
+  if [[ -e "$target/scripts/validate_archive.py" ]]; then
+    [[ -f "$target/scripts/validate_archive.py" && ! -e "$parked" ]] \
+      || { deploy_error "cannot park newly installed validator during restore"; return 1; }
+    mv "$target/scripts/validate_archive.py" "$parked" || return 1
+    deploy_checkpoint restore-validator-parked || return 1
+  fi
+  same_file_identity "$target/scripts/collect_health.sh" "$rollback/scripts/collect_health.sh" \
+    || { deploy_error "restored collector verification failed: $target/scripts/collect_health.sh"; return 1; }
+  same_file_identity "$target/SKILL.md" "$rollback/SKILL.md" \
+    || { deploy_error "restored SKILL verification failed: $target/SKILL.md"; return 1; }
+  [[ ! -e "$target/scripts/validate_archive.py" ]] \
+    || { deploy_error "restored validator absence verification failed: $target/scripts/validate_archive.py"; return 1; }
+  same_file_identity "$merged/scripts/collect_health.sh" "$rollback/scripts/collect_health.sh" \
+    || { deploy_error "merged collector restore verification failed: $merged/scripts/collect_health.sh"; return 1; }
+  same_file_identity "$merged/SKILL.md" "$rollback/SKILL.md" \
+    || { deploy_error "merged SKILL restore verification failed: $merged/SKILL.md"; return 1; }
+  [[ ! -e "$merged/scripts/validate_archive.py" ]] \
+    || { deploy_error "merged validator absence verification failed: $merged/scripts/validate_archive.py"; return 1; }
+  deploy_checkpoint restore-old-views-reverified || return 1
+  if [[ -e "$parked" ]]; then
+    rm -f -- "$parked" || return 1
+    deploy_checkpoint restore-validator-removed || return 1
+  fi
+  verify_notifier "$target" "$rollback" || return 1
+  verify_inventory "$target" false || return 1
+  verify_compatibility_link_matches "$target" "$rollback" || return 1
+}
+
+accept_deployment() {
+  local source_skill=$1 source_collector=$2 source_validator=$3 target=$4 merged=$5 rollback=$6
+  local output report
+  verify_inventory "$target" true || return 1
+  verify_compatibility_link_matches "$target" "$rollback" || return 1
+  verify_view "$source_skill" "$source_collector" "$source_validator" "$target" || return 1
+  deploy_checkpoint acceptance-physical-verified || return 1
+  verify_view "$source_skill" "$source_collector" "$source_validator" "$merged" || return 1
+  deploy_checkpoint acceptance-merged-verified || return 1
+  verify_notifier "$target" "$rollback" || return 1
+  bash -n "$target/scripts/collect_health.sh" || return 1
+  python3 -c 'compile(open(__import__("sys").argv[1], encoding="utf-8").read(), __import__("sys").argv[1], "exec")' "$target/scripts/validate_archive.py" \
+    || return 1
+  validator_smoke "$target/scripts/validate_archive.py" || return 1
+  deploy_checkpoint acceptance-validator-fixtures || return 1
+  output="$(mktemp /tmp/investment-data-collector-accept.XXXXXXXX)" || return 1
+  if ! bash "$target/scripts/collect_health.sh" >"$output"; then
+    rm -f -- "$output"
+    deploy_error "installed collector could not produce a complete report"
+    return
+  fi
+  if ! jq -e '.release.archive_validation | type == "object" and .ok == true' \
+      >/dev/null "$output"; then
+    rm -f -- "$output"
+    deploy_error "installed collector did not validate actual archive semantics"
+    return
+  fi
+  rm -f -- "$output"
+  deploy_checkpoint acceptance-collector-report || return 1
+}
+
+install_and_accept() {
+  local source_skill=$1 source_collector=$2 source_validator=$3 target=$4 merged=$5 rollback=$6
+  install_one "$source_validator" "$target/scripts/validate_archive.py" \
+    "$rollback/scripts/validate_archive.py" install-validator || return 1
+  install_one "$source_collector" "$target/scripts/collect_health.sh" \
+    "$rollback/scripts/collect_health.sh" install-collector || return 1
+  install_one "$source_skill" "$target/SKILL.md" "$rollback/SKILL.md" \
+    install-skill || return 1
+  accept_deployment "$source_skill" "$source_collector" "$source_validator" \
+    "$target" "$merged" "$rollback" || return 1
+}
+
+deploy_paths() {
+  local source_skill=$1 source_collector=$2 source_validator=$3 target=$4 merged=$5 rollback=$6
+  verify_source_files "$source_skill" "$source_collector" "$source_validator" || return 1
+  finish_parked_validator_restore "$source_validator" "$target" "$merged" "$rollback" \
+    || return 1
+  prepare_rollback_copy "$target" "$rollback" || return 1
+  verify_backup_tree "$rollback" || return 1
+  verify_compatibility_link_matches "$target" "$rollback" || return 1
+  verify_notifier "$target" "$rollback" || return 1
+
+  if ! install_and_accept "$source_skill" "$source_collector" "$source_validator" \
+      "$target" "$merged" "$rollback"; then
+    printf 'Deployment failed; restoring verified rollback copy.\n' >&2
+    restore_from_rollback "$target" "$merged" "$rollback" \
+      || deploy_error "deployment and verified restoration both failed"
+    return 1
+  fi
+}
+
+rollback_paths() {
+  local target=$1 merged=$2 rollback=$3 repo_root source_validator
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)" || return 1
+  source_validator="$repo_root/qlib/validate_archive.py"
+  finish_parked_validator_restore "$source_validator" "$target" "$merged" "$rollback" \
+    || return 1
+  restore_from_rollback "$target" "$merged" "$rollback" || return 1
+}
+
+main() {
+  local operation repo_root source_skill source_collector source_validator
+  if (($# == 0)); then
+    operation=deploy
+  elif (($# == 1)) && [[ "$1" == rollback ]]; then
+    operation=rollback
+  else
+    printf 'usage: %s [rollback]\n' "${0##*/}" >&2
+    return 2
+  fi
+
+  for command in bash cp diff find jq mktemp mv python3 readlink rm sha256sum stat; do
+    command -v "$command" >/dev/null 2>&1 \
+      || { deploy_error "required command is unavailable: $command"; return 1; }
+  done
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)" || return 1
+  source_skill="$repo_root/ops/investment-data-project-monitor/SKILL.md"
+  source_collector="$repo_root/ops/investment-data-project-monitor/collect_health.sh"
+  source_validator="$repo_root/qlib/validate_archive.py"
+
+  if [[ "$operation" == deploy ]]; then
+    deploy_paths "$source_skill" "$source_collector" "$source_validator" \
+      "$PRODUCTION_TARGET" "$PRODUCTION_MERGED" "$PRODUCTION_ROLLBACK" || return 1
+  else
+    rollback_paths "$PRODUCTION_TARGET" "$PRODUCTION_MERGED" "$PRODUCTION_ROLLBACK" \
+      || return 1
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/qlib/dump_index_weight.py
+++ b/qlib/dump_index_weight.py
@@ -1,59 +1,114 @@
-from sqlalchemy import create_engine
-import pymysql
-import pandas as pd
-import fire
-import os
 import datetime
+import os
+import re
+from pathlib import Path
+from typing import Optional
 
-def dump_all_to_sqlib_source(skip_exists=False):
-  sqlEngine = create_engine('mysql+pymysql://root:@127.0.0.1/investment_data', pool_recycle=3600)
-  dbConnection = sqlEngine.raw_connection()
+import fire
+import pandas as pd
+from sqlalchemy import create_engine
 
-  index_map = {
-    "csi300" : "399300.SZ",
-    "csi500" : "000905.SH",
-    "csi800" : "000906.SH",
-    "csi1000": "000852.SH",
-    "csiall" : "000985.SH",
-  }
 
-  script_path = os.path.dirname(os.path.realpath(__file__))
-  output_dir = os.environ.get("QLIB_INDEX_DIR", f'{script_path}/qlib_index')
-  os.makedirs(output_dir, exist_ok=True)
+INDEX_MAP = {
+  "csi300": "399300.SZ",
+  "csi500": "000905.SH",
+  "csi800": "000906.SH",
+  "csi1000": "000852.SH",
+  "csiall": "000985.SH",
+}
+SYMBOL_RE = re.compile(r"[A-Z]{2}[A-Z0-9]{6}\Z", re.ASCII)
 
-  for index_name, index_code in index_map.items():
-    filename = f'{output_dir}/{index_name}.txt'
-    if skip_exists and os.path.isfile(filename):
+
+def _validate_target_trade_date(target_trade_date: Optional[str]) -> Optional[str]:
+  if target_trade_date is None:
+    return None
+  if not isinstance(target_trade_date, str):
+    raise ValueError("target_trade_date must be YYYY-MM-DD")
+  try:
+    parsed = datetime.datetime.strptime(target_trade_date, "%Y-%m-%d")
+  except ValueError as exc:
+    raise ValueError("target_trade_date must be YYYY-MM-DD") from exc
+  if parsed.strftime("%Y-%m-%d") != target_trade_date:
+    raise ValueError("target_trade_date must be YYYY-MM-DD")
+  return target_trade_date
+
+
+def dump_all_to_sqlib_source(
+    skip_exists=False,
+    target_trade_date: Optional[str] = None,
+):
+  target_trade_date = _validate_target_trade_date(target_trade_date)
+  final_end_date = target_trade_date or datetime.datetime.today().strftime("%Y-%m-%d")
+  target_clause = ""
+  if target_trade_date is not None:
+    target_clause = f"AND trade_date <= '{target_trade_date}'"
+
+  sql_engine = create_engine(
+      "mysql+pymysql://root:@127.0.0.1/investment_data", pool_recycle=3600
+  )
+  db_connection = sql_engine.raw_connection()
+  try:
+    script_path = os.path.dirname(os.path.realpath(__file__))
+    output_dir = Path(os.environ.get("QLIB_INDEX_DIR", f"{script_path}/qlib_index"))
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for index_name, index_code in INDEX_MAP.items():
+      filename = output_dir / f"{index_name}.txt"
+      if skip_exists and filename.is_file():
         continue
 
-    print("Dumping to file: ", filename)
-    change_date_sql = """
-      select min(trade_date) as change_date from
-      (
-        select trade_date, MD5(GROUP_CONCAT(stock_code)) as signature
-        from ts_index_weight 
-        where index_code = '{}'
-        group by trade_date
-      ) date_sig_table
-      group by signature
-      order by change_date
-    """.format(index_code)
-    change_date_pd = pd.read_sql_query(change_date_sql, dbConnection)["change_date"]
-    result_df_list = []
-    for i in range(len(change_date_pd)):
-      start_date = change_date_pd[i].strftime("%Y-%m-%d")
-      if i == len(change_date_pd) - 1:
-        end_date = datetime.datetime.today().strftime("%Y-%m-%d")
-      else:
-        end_date = (change_date_pd[i+1] - datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+      print("Dumping to file: ", filename)
+      change_date_sql = f"""
+        SELECT MIN(trade_date) AS change_date FROM
+        (
+          SELECT trade_date,
+                 MD5(GROUP_CONCAT(stock_code ORDER BY stock_code SEPARATOR ',')) AS signature
+          FROM ts_index_weight
+          WHERE index_code = '{index_code}'
+            {target_clause}
+          GROUP BY trade_date
+        ) date_sig_table
+        GROUP BY signature
+        ORDER BY change_date
+      """
+      change_dates = pd.read_sql_query(change_date_sql, db_connection)["change_date"]
+      rows = []
+      for index, change_date in enumerate(change_dates):
+        start_date = pd.Timestamp(change_date).strftime("%Y-%m-%d")
+        if index == len(change_dates) - 1:
+          end_date = final_end_date
+        else:
+          end_date = (pd.Timestamp(change_dates.iloc[index + 1]) - datetime.timedelta(days=1)).strftime(
+              "%Y-%m-%d"
+          )
+        if start_date > end_date:
+          raise ValueError(f"Invalid index interval {index_name}: {start_date} > {end_date}")
 
-      sql = f"select concat(substr(stock_code, 8, 2), substr(stock_code, 1, 6)), '{start_date}' as start_date, '{end_date}' as end_date FROM ts_index_weight WHERE index_code = '{index_code}' AND trade_date = '{start_date}'"
-      stock_df = pd.read_sql_query(sql, dbConnection)
-      if stock_df.empty:
-        raise Exception(f"No data for {sql}")
-      result_df_list.append(stock_df)
-    if len(result_df_list) > 0:
-      pd.concat(result_df_list).to_csv(filename, index=False, header=False, sep='\t')
+        sql = f"""
+          SELECT CONCAT(SUBSTR(stock_code, 8, 2), SUBSTR(stock_code, 1, 6)) AS symbol
+          FROM ts_index_weight
+          WHERE index_code = '{index_code}' AND trade_date = '{start_date}'
+          ORDER BY stock_code
+        """
+        stock_df = pd.read_sql_query(sql, db_connection)
+        if stock_df.empty:
+          raise RuntimeError(f"No data for {index_code} at {start_date}")
+        for symbol in stock_df["symbol"]:
+          if not isinstance(symbol, str) or SYMBOL_RE.fullmatch(symbol) is None:
+            raise ValueError(f"Malformed instrument symbol for {index_name}: {symbol!r}")
+          rows.append((symbol, start_date, end_date))
+
+      rows.sort(key=lambda row: (row[0], row[1], row[2]))
+      if len(rows) != len(set(rows)):
+        raise ValueError(f"Duplicate instrument rows for {index_name}")
+      if not rows:
+        raise ValueError(f"No index membership rows for {index_name}")
+      with filename.open("w", encoding="utf-8", newline="\n") as stream:
+        stream.write("".join("\t".join(row) + "\n" for row in rows))
+  finally:
+    db_connection.close()
+    sql_engine.dispose()
+
 
 if __name__ == "__main__":
   fire.Fire(dump_all_to_sqlib_source)

--- a/qlib/normalize.py
+++ b/qlib/normalize.py
@@ -1,6 +1,9 @@
 import fire
 import pandas as pd
 from sqlalchemy import create_engine
+from concurrent.futures import ProcessPoolExecutor
+import datetime
+from typing import Optional
 
 CALENDAR_START_DATE = pd.Timestamp("2000-01-04")
 CALENDAR_EXCHANGE = "SSE"
@@ -30,7 +33,46 @@ class CrowdSourceNormalize(yahoo_collector.YahooNormalizeCN1d):
     result_df["amount"] = df["amount"]
     return result_df
 
-def _load_trade_calendar_list():
+
+class _DateFieldAwareNormalize(Normalize):
+  def format_data(self, df: pd.DataFrame) -> pd.DataFrame:
+    if self.interval != "1d" or df.empty:
+      return df
+
+    value = df.iloc[-1][self._date_field_name]
+    try:
+      parsed = pd.to_datetime(value, format="%Y-%m-%d", errors="raise")
+      if pd.isna(parsed):
+        raise ValueError("invalid final date")
+    except (TypeError, ValueError):
+      return df.iloc[:-1]
+    return df
+
+  def normalize(self):
+    # Upstream uses filesystem enumeration order. Sorting keeps fixed-input
+    # builds independent of directory iteration order.
+    file_list = sorted(self._source_dir.glob("*.csv"), key=lambda path: path.as_posix())
+    with ProcessPoolExecutor(max_workers=self._max_workers) as worker:
+      for _ in worker.map(self._executor, file_list):
+        pass
+
+
+def _canonical_date(value):
+    if not isinstance(value, str):
+        raise ValueError(f"Invalid target_trade_date: {value!r}")
+    try:
+        parsed = datetime.datetime.strptime(value, "%Y-%m-%d")
+    except ValueError as exc:
+        raise ValueError(f"Invalid target_trade_date: {value!r}") from exc
+    if parsed.strftime("%Y-%m-%d") != value:
+        raise ValueError(f"Invalid target_trade_date: {value!r}")
+    return value
+
+
+def _load_trade_calendar_list(target_trade_date=None):
+    if target_trade_date is not None:
+        target_trade_date = _canonical_date(target_trade_date)
+
     sql_engine = create_engine("mysql+pymysql://root:@127.0.0.1/investment_data", pool_recycle=3600)
     db_connection = sql_engine.raw_connection()
     try:
@@ -41,7 +83,7 @@ def _load_trade_calendar_list():
             WHERE exchange = '{CALENDAR_EXCHANGE}'
               AND is_open = 1
               AND date >= '{CALENDAR_START_DATE.date()}'
-              AND date <= CURRENT_DATE
+              AND date <= {f"'{target_trade_date}'" if target_trade_date is not None else "CURRENT_DATE"}
             ORDER BY date
             """,
             db_connection,
@@ -57,17 +99,27 @@ def _load_trade_calendar_list():
         )
     return calendar
 
-def normalize_crowd_source_data(source_dir=None, normalize_dir=None, max_workers=1, interval="1d", date_field_name="tradedate", symbol_field_name="symbol"):
+
+def normalize_crowd_source_data(
+    source_dir=None,
+    normalize_dir=None,
+    max_workers=1,
+    interval="1d",
+    date_field_name="tradedate",
+    symbol_field_name="symbol",
+    target_trade_date: Optional[str] = None,
+):
     import multiprocessing as mp
     mp.set_start_method("spawn", force=True)
-    CrowdSourceNormalize.CALENDAR_LIST = _load_trade_calendar_list()
-    yc = Normalize(
+    CrowdSourceNormalize.CALENDAR_LIST = _load_trade_calendar_list(target_trade_date)
+    yc = _DateFieldAwareNormalize(
         source_dir=source_dir,
         target_dir=normalize_dir,
         normalize_class=CrowdSourceNormalize,
         max_workers=max_workers,
         date_field_name=date_field_name,
         symbol_field_name=symbol_field_name,
+        interval=interval,
     )
     yc.normalize()
 

--- a/qlib/validate_archive.py
+++ b/qlib/validate_archive.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Validate the provenance and date semantics of a qlib release archive."""
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import posixpath
+import re
+import sys
+import tarfile
+from pathlib import PurePosixPath
+
+
+QLIB_COMMIT = "b87a2c294d364a33fb739359886acffe8ec907d1"
+MANIFEST_KEYS = (
+    "release_tag",
+    "target_trade_date",
+    "future_start_date",
+    "future_end_date",
+    "dolt_commit",
+    "investment_data_commit",
+    "qlib_commit",
+    "image_digest",
+    "archive_size_bytes",
+    "archive_sha256",
+)
+REQUIRED_MEMBERS = (
+    "qlib_bin/calendars/day.txt",
+    "qlib_bin/calendars/day_future.txt",
+    "qlib_bin/instruments/all.txt",
+    "qlib_bin/instruments/csi300.txt",
+    "qlib_bin/instruments/csi500.txt",
+    "qlib_bin/instruments/csi800.txt",
+    "qlib_bin/instruments/csi1000.txt",
+    "qlib_bin/instruments/csiall.txt",
+)
+DATE_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}\Z")
+GIT_RE = re.compile(r"[0-9a-f]{40}\Z")
+DOLT_RE = re.compile(r"[0-9a-v]{32}\Z")
+DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
+
+
+class ValidationFailure(Exception):
+    def __init__(self, token):
+        super().__init__(token)
+        self.token = token
+
+
+def _fail(token):
+    raise ValidationFailure(token)
+
+
+def _canonical_date(value):
+    if not isinstance(value, str) or DATE_RE.fullmatch(value) is None:
+        return False
+    try:
+        parsed = datetime.datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        return False
+    return parsed.strftime("%Y-%m-%d") == value
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def _load_manifest(path, expected_tag, require_publishable):
+    try:
+        with open(path, "rb") as stream:
+            raw = stream.read()
+    except OSError:
+        _fail("io-error")
+    try:
+        text = raw.decode("utf-8")
+        pairs = json.loads(text, object_pairs_hook=lambda values: values)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        _fail("invalid-manifest")
+    if not isinstance(pairs, list) or any(
+        not isinstance(pair, tuple) or len(pair) != 2 for pair in pairs
+    ):
+        _fail("invalid-manifest")
+    if tuple(key for key, _ in pairs) != MANIFEST_KEYS:
+        _fail("invalid-manifest")
+    manifest = dict(pairs)
+    required_string_fields = MANIFEST_KEYS[:7] + ("archive_sha256",)
+    if any(not isinstance(manifest[key], str) for key in required_string_fields):
+        _fail("invalid-manifest")
+    if manifest["image_digest"] is not None and not isinstance(manifest["image_digest"], str):
+        _fail("invalid-manifest")
+    if any(not _canonical_date(manifest[key]) for key in MANIFEST_KEYS[:4]):
+        _fail("invalid-manifest")
+    if manifest["release_tag"] != expected_tag:
+        _fail("invalid-manifest")
+    if DOLT_RE.fullmatch(manifest["dolt_commit"]) is None:
+        _fail("invalid-manifest")
+    if GIT_RE.fullmatch(manifest["investment_data_commit"]) is None:
+        _fail("invalid-manifest")
+    if manifest["qlib_commit"] != QLIB_COMMIT:
+        _fail("invalid-manifest")
+    image_digest = manifest["image_digest"]
+    if image_digest is not None and DIGEST_RE.fullmatch(image_digest) is None:
+        _fail("invalid-manifest")
+    if require_publishable and image_digest is None:
+        _fail("invalid-manifest")
+    size = manifest["archive_size_bytes"]
+    if isinstance(size, bool) or not isinstance(size, int) or size <= 0:
+        _fail("invalid-manifest")
+    if DIGEST_RE.fullmatch(manifest["archive_sha256"]) is None:
+        _fail("invalid-manifest")
+    return manifest, "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def _safe_member_name(member):
+    name = member.name
+    if not name or "\\" in name or name.startswith("/"):
+        return None
+    trimmed = name[:-1] if name.endswith("/") else name
+    if not trimmed or posixpath.normpath(trimmed) != trimmed:
+        return None
+    parts = PurePosixPath(trimmed).parts
+    if any(part in ("", ".", "..") for part in parts):
+        return None
+    if trimmed != "qlib_bin" and not trimmed.startswith("qlib_bin/"):
+        return None
+    return trimmed
+
+
+def _scan_archive(path):
+    try:
+        archive = tarfile.open(path, mode="r:gz")
+    except (OSError, EOFError, tarfile.TarError):
+        _fail("archive-open-failed")
+    try:
+        try:
+            members = archive.getmembers()
+        except (OSError, EOFError, tarfile.TarError):
+            _fail("archive-open-failed")
+        safe = {}
+        for member in members:
+            name = _safe_member_name(member)
+            if name is None or name in safe:
+                _fail("unsafe-archive-member")
+            if not (member.isdir() or member.isfile()):
+                _fail("unsafe-archive-member")
+            if getattr(member, "sparse", None):
+                _fail("unsafe-archive-member")
+            safe[name] = member
+
+        required = {}
+        for name in REQUIRED_MEMBERS:
+            member = safe.get(name)
+            if member is None or not member.isfile():
+                _fail("missing-required-member")
+            try:
+                stream = archive.extractfile(member)
+                if stream is None:
+                    _fail("missing-required-member")
+                required[name] = stream.read()
+            except (OSError, EOFError, tarfile.TarError):
+                _fail("archive-open-failed")
+        return required
+    finally:
+        archive.close()
+
+
+def _text_lines(raw):
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        _fail("malformed-required-member")
+    if not text or "\r" in text or not text.endswith("\n"):
+        _fail("malformed-required-member")
+    lines = text[:-1].split("\n")
+    if not lines or any(not line for line in lines):
+        _fail("malformed-required-member")
+    return lines
+
+
+def _calendar(raw):
+    lines = _text_lines(raw)
+    if any(not _canonical_date(value) for value in lines):
+        _fail("malformed-required-member")
+    if lines != sorted(set(lines)):
+        _fail("malformed-required-member")
+    return lines
+
+
+def _instruments(raw):
+    lines = _text_lines(raw)
+    rows = []
+    for line in lines:
+        fields = line.split("\t")
+        if len(fields) != 3:
+            _fail("malformed-required-member")
+        symbol, start, end = fields
+        if not symbol or not _canonical_date(start) or not _canonical_date(end) or start > end:
+            _fail("malformed-required-member")
+        rows.append((symbol, start, end))
+    if rows != sorted(set(rows), key=lambda row: (row[0], row[1], row[2])):
+        _fail("malformed-required-member")
+    return rows
+
+
+def validate(archive_path, manifest_path, expected_tag, require_publishable=False):
+    manifest, manifest_digest = _load_manifest(
+        manifest_path, expected_tag, require_publishable
+    )
+    try:
+        archive_size = os.path.getsize(archive_path)
+        archive_digest = _sha256(archive_path)
+    except OSError:
+        _fail("io-error")
+    if (
+        archive_size != manifest["archive_size_bytes"]
+        or archive_digest != manifest["archive_sha256"]
+    ):
+        _fail("archive-identity-mismatch")
+
+    members = _scan_archive(archive_path)
+    day = _calendar(members[REQUIRED_MEMBERS[0]])
+    day_future = _calendar(members[REQUIRED_MEMBERS[1]])
+    instruments = [_instruments(members[name]) for name in REQUIRED_MEMBERS[2:]]
+
+    target = manifest["target_trade_date"]
+    if day[-1] != target or any(max(row[2] for row in rows) != target for rows in instruments):
+        _fail("target-mismatch")
+    if len(day_future) <= len(day):
+        _fail("future-mismatch")
+    if day_future[: len(day)] != day:
+        _fail("prefix-mismatch")
+    if (
+        day_future[len(day)] != manifest["future_start_date"]
+        or day_future[-1] != manifest["future_end_date"]
+    ):
+        _fail("future-mismatch")
+
+    return {
+        "ok": True,
+        "result": {
+            "archive_sha256": archive_digest,
+            "manifest_sha256": manifest_digest,
+            "archive_size_bytes": archive_size,
+            "target_trade_date": target,
+            "future_start_date": manifest["future_start_date"],
+            "future_end_date": manifest["future_end_date"],
+        },
+    }
+
+
+def _parse_args(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--archive", required=True)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--expected-tag", required=True, type=_expected_tag)
+    parser.add_argument("--require-publishable", action="store_true")
+    return parser.parse_args(argv)
+
+
+def _expected_tag(value):
+    if not _canonical_date(value):
+        raise argparse.ArgumentTypeError("expected tag must be YYYY-MM-DD")
+    return value
+
+
+def main(argv=None):
+    args = _parse_args(argv)
+    try:
+        result = validate(
+            args.archive,
+            args.manifest,
+            args.expected_tag,
+            args.require_publishable,
+        )
+    except ValidationFailure as exc:
+        print(json.dumps({"ok": False, "error": exc.token}, separators=(",", ":")))
+        return 1
+    print(json.dumps(result, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_qlib_normalize.py
+++ b/tests/test_qlib_normalize.py
@@ -1,0 +1,139 @@
+import importlib.util
+import inspect
+from pathlib import Path
+import sys
+import types
+from typing import Optional
+import unittest
+from unittest import mock
+
+import pandas as pd
+
+
+class _UpstreamNormalize:
+    def __init__(
+        self,
+        source_dir=None,
+        target_dir=None,
+        normalize_class=None,
+        max_workers=1,
+        date_field_name="date",
+        symbol_field_name="symbol",
+        **kwargs,
+    ):
+        self._source_dir = Path(source_dir or ".")
+        self._target_dir = Path(target_dir or ".")
+        self._max_workers = max_workers
+        self._date_field_name = date_field_name
+        self._symbol_field_name = symbol_field_name
+        self.interval = kwargs.get("interval", "1d")
+
+    def normalize(self):
+        return None
+
+
+class _YahooNormalize:
+    def _get_calendar_list(self):
+        return []
+
+    def _manual_adj_data(self, df):
+        return df
+
+
+def _load_module():
+    try:
+        import data_collector.base  # noqa: F401
+        import data_collector.yahoo  # noqa: F401
+    except ImportError:
+        data_collector = types.ModuleType("data_collector")
+        base = types.ModuleType("data_collector.base")
+        base.Normalize = _UpstreamNormalize
+        yahoo = types.ModuleType("data_collector.yahoo")
+        yahoo.collector = types.SimpleNamespace(YahooNormalizeCN1d=_YahooNormalize)
+        sys.modules.update(
+            {
+                "data_collector": data_collector,
+                "data_collector.base": base,
+                "data_collector.yahoo": yahoo,
+            }
+        )
+    try:
+        import fire  # noqa: F401
+    except ImportError:
+        fire = types.ModuleType("fire")
+        fire.Fire = lambda *_args, **_kwargs: None
+        sys.modules["fire"] = fire
+    path = Path(__file__).resolve().parents[1] / "qlib/normalize.py"
+    spec = importlib.util.spec_from_file_location("tested_qlib_normalize", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+
+
+class DateFieldAwareNormalizeTest(unittest.TestCase):
+    def make_normalizer(self, interval="1d", date_field_name="tradedate"):
+        normalizer = MODULE._DateFieldAwareNormalize.__new__(MODULE._DateFieldAwareNormalize)
+        normalizer._date_field_name = date_field_name
+        normalizer.interval = interval
+        return normalizer
+
+    def test_two_valid_tradedate_rows_are_retained(self):
+        frame = pd.DataFrame(
+            {"tradedate": ["2026-07-17", "2026-07-20"], "close": [1.0, 2.0]}
+        )
+        result = self.make_normalizer().format_data(frame)
+        pd.testing.assert_frame_equal(result, frame)
+
+    def test_invalid_final_value_removes_only_that_row(self):
+        frame = pd.DataFrame(
+            {"tradedate": ["2026-07-17", "not-a-date"], "close": [1.0, 2.0]}
+        )
+        result = self.make_normalizer().format_data(frame)
+        pd.testing.assert_frame_equal(result, frame.iloc[:-1])
+
+    def test_empty_dataframe_is_returned_unchanged(self):
+        frame = pd.DataFrame(columns=["tradedate", "close"])
+        self.assertIs(self.make_normalizer().format_data(frame), frame)
+
+    def test_missing_configured_date_column_raises_key_error(self):
+        frame = pd.DataFrame({"date": ["2026-07-20"]})
+        with self.assertRaises(KeyError):
+            self.make_normalizer().format_data(frame)
+
+    def test_unexpected_parser_exception_propagates(self):
+        frame = pd.DataFrame({"tradedate": ["2026-07-20"]})
+        with mock.patch.object(MODULE.pd, "to_datetime", side_effect=RuntimeError("boom")):
+            with self.assertRaisesRegex(RuntimeError, "boom"):
+                self.make_normalizer().format_data(frame)
+
+    def test_non_daily_interval_is_returned_unchanged(self):
+        frame = pd.DataFrame({"tradedate": ["not-a-date"]})
+        self.assertIs(self.make_normalizer(interval="1m").format_data(frame), frame)
+
+    def test_fire_signature_and_none_calendar_compatibility(self):
+        parameter = inspect.signature(
+            MODULE.normalize_crowd_source_data
+        ).parameters["target_trade_date"]
+        self.assertIsNone(parameter.default)
+        self.assertEqual(parameter.annotation, Optional[str])
+
+        engine = mock.Mock()
+        connection = engine.raw_connection.return_value
+        calendar = pd.DataFrame({"date": pd.to_datetime(["2026-07-17", "2026-07-20"])})
+        with mock.patch.object(MODULE, "create_engine", return_value=engine), mock.patch.object(
+            MODULE.pd, "read_sql", return_value=calendar
+        ) as read_sql:
+            self.assertEqual(
+                MODULE._load_trade_calendar_list(None),
+                list(calendar["date"]),
+            )
+        self.assertIn("date <= CURRENT_DATE", read_sql.call_args.args[0])
+        connection.close.assert_called_once_with()
+        engine.dispose.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_safety.py
+++ b/tests/test_release_safety.py
@@ -1,0 +1,3652 @@
+import gzip
+import hashlib
+import importlib.util
+import inspect
+import io
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import types
+from typing import Optional
+import unittest
+from unittest import mock
+
+import pandas as pd
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "qlib/validate_archive.py"
+QLIB_COMMIT = "b87a2c294d364a33fb739359886acffe8ec907d1"
+COMPATIBILITY_LINK_NAME = "investment-data-project-monitor"
+COMPATIBILITY_LINK_TARGET = "/localhome/local-dichen/.claude/skills/investment-data-project-monitor"
+REQUIRED = {
+    "qlib_bin/calendars/day.txt": "2026-07-17\n2026-07-20\n",
+    "qlib_bin/calendars/day_future.txt": "2026-07-17\n2026-07-20\n2026-07-21\n2026-12-31\n",
+    "qlib_bin/instruments/all.txt": "sh600000\t2026-07-17\t2026-07-20\n",
+    "qlib_bin/instruments/csi300.txt": "sh600000\t2026-07-17\t2026-07-20\n",
+    "qlib_bin/instruments/csi500.txt": "sh600000\t2026-07-17\t2026-07-20\n",
+    "qlib_bin/instruments/csi800.txt": "sh600000\t2026-07-17\t2026-07-20\n",
+    "qlib_bin/instruments/csi1000.txt": "sh600000\t2026-07-17\t2026-07-20\n",
+    "qlib_bin/instruments/csiall.txt": "sh600000\t2026-07-17\t2026-07-20\n",
+}
+
+
+def manifest_payload(archive, image_digest="sha256:" + "a" * 64):
+    return {
+        "release_tag": "2026-07-20",
+        "target_trade_date": "2026-07-20",
+        "future_start_date": "2026-07-21",
+        "future_end_date": "2026-12-31",
+        "dolt_commit": "9vtplc2tar9ver7p6s1bus2oiedjvtqo",
+        "investment_data_commit": "0" * 40,
+        "qlib_commit": QLIB_COMMIT,
+        "image_digest": image_digest,
+        "archive_size_bytes": archive.stat().st_size,
+        "archive_sha256": "sha256:" + hashlib.sha256(archive.read_bytes()).hexdigest(),
+    }
+
+
+def write_manifest(path, payload):
+    path.write_text(json.dumps(payload, separators=(",", ":")) + "\n", encoding="utf-8")
+
+
+def build_archive(path, members=None, extras=()):
+    members = dict(REQUIRED if members is None else members)
+    tar_buffer = io.BytesIO()
+    with tarfile.open(fileobj=tar_buffer, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+        for name in sorted(members):
+            data = members[name].encode("utf-8")
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            info.mode = 0o644
+            info.uid = info.gid = 0
+            info.mtime = 1784505600
+            archive.addfile(info, io.BytesIO(data))
+        for info, data in extras:
+            archive.addfile(info, io.BytesIO(data) if data is not None else None)
+    with path.open("wb") as output:
+        with gzip.GzipFile(filename="", mode="wb", compresslevel=9, fileobj=output, mtime=0) as zipped:
+            zipped.write(tar_buffer.getvalue())
+    return path
+
+
+def build_pair(root, members=None, extras=(), image_digest="sha256:" + "a" * 64):
+    archive = build_archive(root / "qlib_bin.tar.gz", members, extras)
+    manifest = root / "qlib_bin.manifest.json"
+    write_manifest(manifest, manifest_payload(archive, image_digest))
+    return archive, manifest
+
+
+def run_validator(archive, manifest, *extra):
+    return subprocess.run(
+        [
+            sys.executable,
+            str(VALIDATOR),
+            "--archive",
+            str(archive),
+            "--manifest",
+            str(manifest),
+            "--expected-tag",
+            "2026-07-20",
+            *extra,
+        ],
+        text=True,
+        capture_output=True,
+    )
+
+
+def load_fire_module(relative, name):
+    fire = types.ModuleType("fire")
+    fire.Fire = lambda *_args, **_kwargs: None
+    with mock.patch.dict(sys.modules, {"fire": fire}):
+        spec = importlib.util.spec_from_file_location(name, ROOT / relative)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+class ArchiveValidatorTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def assert_failure(self, archive, manifest, token, *extra):
+        result = run_validator(archive, manifest, *extra)
+        self.assertEqual(result.returncode, 1, result.stderr)
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(result.stdout, json.dumps({"ok": False, "error": token}, separators=(",", ":")) + "\n")
+
+    def test_success_reports_both_complete_file_digests(self):
+        archive, manifest = build_pair(self.root)
+        result = run_validator(archive, manifest, "--require-publishable")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(result.stdout.endswith("\n"))
+        report = json.loads(result.stdout)
+        self.assertEqual(
+            report,
+            {
+                "ok": True,
+                "result": {
+                    "archive_sha256": "sha256:" + hashlib.sha256(archive.read_bytes()).hexdigest(),
+                    "manifest_sha256": "sha256:" + hashlib.sha256(manifest.read_bytes()).hexdigest(),
+                    "archive_size_bytes": archive.stat().st_size,
+                    "target_trade_date": "2026-07-20",
+                    "future_start_date": "2026-07-21",
+                    "future_end_date": "2026-12-31",
+                },
+            },
+        )
+
+    def test_null_image_digest_is_diagnostic_only(self):
+        archive, manifest = build_pair(self.root, image_digest=None)
+        self.assertEqual(run_validator(archive, manifest).returncode, 0)
+        self.assert_failure(archive, manifest, "invalid-manifest", "--require-publishable")
+
+    def test_manifest_requires_exact_fields_order_types_and_identity(self):
+        archive, manifest = build_pair(self.root)
+        base = manifest_payload(archive)
+        mutations = []
+        missing = dict(base)
+        missing.pop("future_end_date")
+        mutations.append(json.dumps(missing, separators=(",", ":")) + "\n")
+        extra = dict(base)
+        extra["extra"] = True
+        mutations.append(json.dumps(extra, separators=(",", ":")) + "\n")
+        reversed_items = dict(reversed(list(base.items())))
+        mutations.append(json.dumps(reversed_items, separators=(",", ":")) + "\n")
+        duplicate = json.dumps(base, separators=(",", ":"))
+        duplicate = duplicate[:-1] + ',"release_tag":"2026-07-20"}\n'
+        mutations.append(duplicate)
+        wrong_type = dict(base)
+        wrong_type["archive_size_bytes"] = True
+        mutations.append(json.dumps(wrong_type, separators=(",", ":")) + "\n")
+        wrong_qlib = dict(base)
+        wrong_qlib["qlib_commit"] = "1" * 40
+        mutations.append(json.dumps(wrong_qlib, separators=(",", ":")) + "\n")
+        uppercase = dict(base)
+        uppercase["archive_sha256"] = "sha256:" + "A" * 64
+        mutations.append(json.dumps(uppercase, separators=(",", ":")) + "\n")
+        for index, text in enumerate(mutations):
+            with self.subTest(index=index):
+                manifest.write_text(text, encoding="utf-8")
+                self.assert_failure(archive, manifest, "invalid-manifest")
+
+    def test_every_manifest_field_type_and_canonical_form_is_enforced(self):
+        archive, manifest = build_pair(self.root)
+        base = manifest_payload(archive)
+        cases = {
+            "release-tag-type": ("release_tag", None),
+            "release-tag-form": ("release_tag", "2026-7-20"),
+            "target-date": ("target_trade_date", "2026-02-30"),
+            "future-start": ("future_start_date", "2026-07-21T00:00:00Z"),
+            "future-end": ("future_end_date", "2026-13-31"),
+            "dolt-uppercase": ("dolt_commit", "Z" * 32),
+            "dolt-short": ("dolt_commit", "a" * 31),
+            "investment-uppercase": ("investment_data_commit", "A" * 40),
+            "investment-short": ("investment_data_commit", "a" * 39),
+            "qlib-type": ("qlib_commit", None),
+            "qlib-wrong": ("qlib_commit", "0" * 40),
+            "image-prefix": ("image_digest", "SHA256:" + "a" * 64),
+            "image-uppercase": ("image_digest", "sha256:" + "A" * 64),
+            "image-short": ("image_digest", "sha256:" + "a" * 63),
+            "size-zero": ("archive_size_bytes", 0),
+            "size-negative": ("archive_size_bytes", -1),
+            "size-float": ("archive_size_bytes", 1.0),
+            "size-string": ("archive_size_bytes", "1"),
+            "archive-prefix": ("archive_sha256", "SHA256:" + "a" * 64),
+            "archive-uppercase": ("archive_sha256", "sha256:" + "A" * 64),
+            "archive-type": ("archive_sha256", None),
+        }
+        for label, (field, value) in cases.items():
+            with self.subTest(label=label):
+                payload = dict(base)
+                payload[field] = value
+                write_manifest(manifest, payload)
+                self.assert_failure(archive, manifest, "invalid-manifest")
+
+    def test_each_required_current_member_must_end_at_target(self):
+        for name in [REQUIRED.keys().__iter__().__next__(), *list(REQUIRED)[2:]]:
+            with self.subTest(name=name):
+                members = dict(REQUIRED)
+                if name.endswith("day.txt"):
+                    members[name] = "2026-07-17\n"
+                else:
+                    members[name] = "sh600000\t2026-07-17\t2026-07-17\n"
+                archive, manifest = build_pair(self.root, members)
+                self.assert_failure(archive, manifest, "target-mismatch")
+
+    def test_missing_and_malformed_required_members(self):
+        members = dict(REQUIRED)
+        members.pop("qlib_bin/instruments/csi300.txt")
+        archive, manifest = build_pair(self.root, members)
+        self.assert_failure(archive, manifest, "missing-required-member")
+
+        members = dict(REQUIRED)
+        members["qlib_bin/instruments/all.txt"] = "sh600000 2026-07-17 2026-07-20\n"
+        archive, manifest = build_pair(self.root, members)
+        self.assert_failure(archive, manifest, "malformed-required-member")
+
+    def test_every_required_member_missing_duplicate_nonregular_and_malformed(self):
+        for name in REQUIRED:
+            with self.subTest(name=name, condition="missing"):
+                members = dict(REQUIRED)
+                members.pop(name)
+                archive, manifest = build_pair(self.root, members)
+                self.assert_failure(archive, manifest, "missing-required-member")
+
+            with self.subTest(name=name, condition="duplicate"):
+                duplicate = tarfile.TarInfo(name)
+                duplicate.size = 1
+                archive, manifest = build_pair(
+                    self.root, extras=((duplicate, b"x"),)
+                )
+                self.assert_failure(archive, manifest, "unsafe-archive-member")
+
+            with self.subTest(name=name, condition="nonregular"):
+                members = dict(REQUIRED)
+                members.pop(name)
+                directory = tarfile.TarInfo(name)
+                directory.type = tarfile.DIRTYPE
+                archive, manifest = build_pair(
+                    self.root, members, extras=((directory, None),)
+                )
+                self.assert_failure(archive, manifest, "missing-required-member")
+
+            with self.subTest(name=name, condition="malformed"):
+                members = dict(REQUIRED)
+                if "/calendars/" in name:
+                    members[name] = "not-a-date\n"
+                else:
+                    members[name] = "SH600000 2026-07-17 2026-07-20\n"
+                archive, manifest = build_pair(self.root, members)
+                self.assert_failure(archive, manifest, "malformed-required-member")
+
+    def test_future_and_prefix_mismatches_have_stable_tokens(self):
+        members = dict(REQUIRED)
+        members["qlib_bin/calendars/day_future.txt"] = "2026-07-17\n2026-07-20\n2026-07-22\n2026-12-31\n"
+        archive, manifest = build_pair(self.root, members)
+        self.assert_failure(archive, manifest, "future-mismatch")
+
+        members = dict(REQUIRED)
+        members["qlib_bin/calendars/day_future.txt"] = "2026-07-18\n2026-07-20\n2026-07-21\n2026-12-31\n"
+        archive, manifest = build_pair(self.root, members)
+        self.assert_failure(archive, manifest, "prefix-mismatch")
+
+    def test_archive_identity_and_open_failures(self):
+        archive, manifest = build_pair(self.root)
+        payload = manifest_payload(archive)
+        payload["archive_size_bytes"] += 1
+        write_manifest(manifest, payload)
+        self.assert_failure(archive, manifest, "archive-identity-mismatch")
+
+        archive.write_bytes(b"not a gzip archive")
+        write_manifest(manifest, manifest_payload(archive))
+        self.assert_failure(archive, manifest, "archive-open-failed")
+
+        self.assert_failure(self.root / "absent.tar.gz", manifest, "io-error")
+
+    def test_full_tar_scan_rejects_unsafe_paths_duplicates_and_types(self):
+        unsafe = []
+        for name in (
+            "",
+            ".",
+            "./qlib_bin/escape",
+            "/absolute",
+            "../escape",
+            "qlib_bin/../escape",
+            "qlib_bin/nested/../../escape",
+            "qlib_bin//double",
+            "qlib_bin/back\\slash",
+            "outside/file",
+        ):
+            info = tarfile.TarInfo(name)
+            info.size = 1
+            unsafe.append((name, info, b"x"))
+        for type_name, type_value in (
+            ("symlink", tarfile.SYMTYPE),
+            ("hardlink", tarfile.LNKTYPE),
+            ("char", tarfile.CHRTYPE),
+            ("block", tarfile.BLKTYPE),
+            ("fifo", tarfile.FIFOTYPE),
+            ("socket", b"s"),
+            ("sparse", tarfile.GNUTYPE_SPARSE),
+            ("unknown", b"V"),
+        ):
+            info = tarfile.TarInfo(f"qlib_bin/{type_name}")
+            info.type = type_value
+            info.linkname = "qlib_bin/calendars/day.txt"
+            unsafe.append((type_name, info, None))
+        duplicate = tarfile.TarInfo("qlib_bin/calendars/day.txt")
+        duplicate.size = 1
+        unsafe.append(("duplicate", duplicate, b"x"))
+        for label, info, data in unsafe:
+            with self.subTest(label=label):
+                archive, manifest = build_pair(self.root, extras=((info, data),))
+                self.assert_failure(archive, manifest, "unsafe-archive-member")
+
+    def test_validator_never_calls_any_extraction_api(self):
+        archive, manifest = build_pair(self.root)
+        spec = importlib.util.spec_from_file_location("validator_no_extract", VALIDATOR)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        with mock.patch.object(
+            module.tarfile.TarFile,
+            "extract",
+            side_effect=AssertionError("extract called"),
+        ), mock.patch.object(
+            module.tarfile.TarFile,
+            "extractall",
+            side_effect=AssertionError("extractall called"),
+        ):
+            report = module.validate(
+                archive, manifest, "2026-07-20", require_publishable=True
+            )
+        self.assertTrue(report["ok"])
+
+    def test_every_handled_error_token_has_a_real_small_fixture(self):
+        seen = set()
+
+        archive, manifest = build_pair(self.root)
+        manifest.write_text("{}\n", encoding="utf-8")
+        self.assert_failure(archive, manifest, "invalid-manifest")
+        seen.add("invalid-manifest")
+
+        absent = self.root / "absent.tar.gz"
+        self.assert_failure(absent, manifest, "invalid-manifest")
+        archive, manifest = build_pair(self.root)
+        self.assert_failure(absent, manifest, "io-error")
+        seen.add("io-error")
+
+        archive.write_bytes(b"broken")
+        write_manifest(manifest, manifest_payload(archive))
+        self.assert_failure(archive, manifest, "archive-open-failed")
+        seen.add("archive-open-failed")
+
+        info = tarfile.TarInfo("qlib_bin/link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "/etc/passwd"
+        archive, manifest = build_pair(self.root, extras=((info, None),))
+        self.assert_failure(archive, manifest, "unsafe-archive-member")
+        seen.add("unsafe-archive-member")
+
+        members = dict(REQUIRED)
+        members.pop("qlib_bin/instruments/csi300.txt")
+        archive, manifest = build_pair(self.root, members)
+        self.assert_failure(archive, manifest, "missing-required-member")
+        seen.add("missing-required-member")
+
+        members = dict(REQUIRED)
+        members["qlib_bin/instruments/csi300.txt"] = "bad\n"
+        archive, manifest = build_pair(self.root, members)
+        self.assert_failure(archive, manifest, "malformed-required-member")
+        seen.add("malformed-required-member")
+
+        archive, manifest = build_pair(self.root)
+        payload = manifest_payload(archive)
+        payload["archive_size_bytes"] += 1
+        write_manifest(manifest, payload)
+        self.assert_failure(archive, manifest, "archive-identity-mismatch")
+        seen.add("archive-identity-mismatch")
+
+        members = dict(REQUIRED)
+        members["qlib_bin/instruments/csi300.txt"] = (
+            "SH600000\t2026-07-17\t2026-07-17\n"
+        )
+        archive, manifest = build_pair(self.root, members)
+        self.assert_failure(archive, manifest, "target-mismatch")
+        seen.add("target-mismatch")
+
+        members = dict(REQUIRED)
+        members["qlib_bin/calendars/day_future.txt"] = (
+            "2026-07-17\n2026-07-20\n2026-07-22\n2026-12-31\n"
+        )
+        archive, manifest = build_pair(self.root, members)
+        self.assert_failure(archive, manifest, "future-mismatch")
+        seen.add("future-mismatch")
+
+        members["qlib_bin/calendars/day_future.txt"] = (
+            "2026-07-18\n2026-07-20\n2026-07-21\n2026-12-31\n"
+        )
+        archive, manifest = build_pair(self.root, members)
+        self.assert_failure(archive, manifest, "prefix-mismatch")
+        seen.add("prefix-mismatch")
+
+        self.assertEqual(
+            seen,
+            {
+                "invalid-manifest",
+                "io-error",
+                "archive-open-failed",
+                "unsafe-archive-member",
+                "missing-required-member",
+                "malformed-required-member",
+                "archive-identity-mismatch",
+                "target-mismatch",
+                "future-mismatch",
+                "prefix-mismatch",
+            },
+        )
+
+    def test_complete_scan_occurs_before_member_body_read(self):
+        spec = importlib.util.spec_from_file_location("validator_under_test", VALIDATOR)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        class FakeArchive:
+            def getmembers(self):
+                members = []
+                for name in module.REQUIRED_MEMBERS:
+                    info = tarfile.TarInfo(name)
+                    info.size = 1
+                    members.append(info)
+                unsafe = tarfile.TarInfo("qlib_bin/unsafe")
+                unsafe.type = tarfile.SYMTYPE
+                unsafe.linkname = "/etc/passwd"
+                members.append(unsafe)
+                return members
+
+            def extractfile(self, _member):
+                raise AssertionError("member body read before complete scan")
+
+            def close(self):
+                pass
+
+        with mock.patch.object(module.tarfile, "open", return_value=FakeArchive()):
+            with self.assertRaises(module.ValidationFailure) as raised:
+                module._scan_archive("unused")
+        self.assertEqual(raised.exception.token, "unsafe-archive-member")
+
+    def test_cli_syntax_errors_exit_two_with_empty_stdout(self):
+        result = subprocess.run([sys.executable, str(VALIDATOR)], text=True, capture_output=True)
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("usage:", result.stderr)
+        result = subprocess.run(
+            [sys.executable, str(VALIDATOR), "--archive", "x", "--manifest", "y", "--expected-tag", "2026-7-20"],
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(result.stdout, "")
+
+    def test_fixed_input_archives_and_manifests_are_byte_identical(self):
+        first = self.root / "first"
+        second = self.root / "second"
+        first.mkdir()
+        second.mkdir()
+        first_pair = build_pair(first)
+        second_pair = build_pair(second)
+        self.assertEqual(first_pair[0].read_bytes(), second_pair[0].read_bytes())
+        self.assertEqual(first_pair[1].read_bytes(), second_pair[1].read_bytes())
+        self.assertEqual(first_pair[0].read_bytes()[4:8], b"\x00\x00\x00\x00")
+        with tarfile.open(first_pair[0], "r:gz") as archive:
+            names = [member.name for member in archive.getmembers()]
+            self.assertEqual(names, sorted(names))
+            for member in archive.getmembers():
+                self.assertEqual((member.uid, member.gid, member.mode, member.mtime), (0, 0, 0o644, 1784505600))
+
+
+class GeneratorContractTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.index = load_fire_module("qlib/dump_index_weight.py", "tested_index_generator")
+        self.calendar = load_fire_module(
+            "tushare/dump_day_calendar.py", "tested_calendar_generator"
+        )
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def _run_index(self, symbols, target_trade_date="2026-07-20"):
+        engine = mock.Mock()
+        connection = engine.raw_connection.return_value
+        output = self.root / "index"
+        change_dates = pd.DataFrame(
+            {"change_date": pd.to_datetime(["2026-07-17"])}
+        )
+        constituents = pd.DataFrame({"symbol": symbols})
+        with mock.patch.dict(self.index.INDEX_MAP, {"csi300": "399300.SZ"}, clear=True), mock.patch.dict(
+            os.environ, {"QLIB_INDEX_DIR": str(output)}
+        ), mock.patch.object(
+            self.index, "create_engine", return_value=engine
+        ), mock.patch.object(
+            self.index.pd,
+            "read_sql_query",
+            side_effect=[change_dates, constituents],
+        ) as read_sql:
+            self.index.dump_all_to_sqlib_source(
+                target_trade_date=target_trade_date
+            )
+        connection.close.assert_called_once_with()
+        engine.dispose.assert_called_once_with()
+        return output / "csi300.txt", [call.args[0] for call in read_sql.call_args_list]
+
+    def test_all_three_fire_signatures_use_exact_optional_string_annotation(self):
+        for function in (
+            self.index.dump_all_to_sqlib_source,
+            self.calendar.dump_calendar_to_qlib_dir,
+        ):
+            with self.subTest(function=function.__name__):
+                parameter = inspect.signature(function).parameters["target_trade_date"]
+                self.assertIsNone(parameter.default)
+                self.assertEqual(parameter.annotation, Optional[str])
+
+    def test_index_serialization_is_canonical_for_shuffled_symbols(self):
+        output, queries = self._run_index(["SZ000002", "SHT00018", "SH600000"])
+        self.assertEqual(
+            output.read_bytes(),
+            b"SH600000\t2026-07-17\t2026-07-20\n"
+            b"SHT00018\t2026-07-17\t2026-07-20\n"
+            b"SZ000002\t2026-07-17\t2026-07-20\n",
+        )
+        self.assertIn(
+            "GROUP_CONCAT(stock_code ORDER BY stock_code SEPARATOR ',')", queries[0]
+        )
+        self.assertIn("ORDER BY stock_code", queries[1])
+
+    def test_index_none_retains_today_bounded_diagnostic_behavior(self):
+        class FixedDateTime(self.index.datetime.datetime):
+            @classmethod
+            def today(cls):
+                return cls(2026, 7, 23)
+
+        with mock.patch.object(self.index.datetime, "datetime", FixedDateTime):
+            output, queries = self._run_index(["SH600000"], None)
+        self.assertEqual(
+            output.read_text(encoding="utf-8"),
+            "SH600000\t2026-07-17\t2026-07-23\n",
+        )
+        self.assertNotIn("trade_date <=", queries[0])
+
+    def test_index_rejects_null_empty_and_malformed_symbols_without_serializing(self):
+        malformed = (
+            None,
+            "",
+            "600000",
+            "SH60000",
+            "sh600000",
+            "SH60000-",
+            "SH600000\tbad",
+            42,
+            pd.NA,
+        )
+        for symbol in malformed:
+            with self.subTest(symbol=repr(symbol)):
+                output_root = self.root / "index"
+                with self.assertRaises(ValueError):
+                    self._run_index([symbol])
+                self.assertFalse((output_root / "csi300.txt").exists())
+
+    def test_index_rejects_duplicate_emitted_tuples(self):
+        with self.assertRaisesRegex(ValueError, "Duplicate instrument rows"):
+            self._run_index(["SH600000", "SH600000"])
+
+    def test_calendar_none_retains_unbounded_future_serialization(self):
+        qlib_root = self.root / "qlib"
+        (qlib_root / "calendars").mkdir(parents=True)
+        (qlib_root / "calendars/day.txt").write_text(
+            "2026-07-17\n2026-07-20\n", encoding="utf-8"
+        )
+        engine = mock.Mock()
+        dates = pd.DataFrame(
+            {"date": pd.to_datetime(["2026-07-17", "2026-07-20", "2026-07-21"])}
+        )
+        with mock.patch.object(
+            self.calendar, "create_engine", return_value=engine
+        ), mock.patch.object(self.calendar.pd, "read_sql", return_value=dates) as read_sql:
+            self.calendar.dump_calendar_to_qlib_dir(
+                str(qlib_root), target_trade_date=None
+            )
+        self.assertEqual(
+            (qlib_root / "calendars/day_future.txt").read_bytes(),
+            b"2026-07-17\n2026-07-20\n2026-07-21\n",
+        )
+        self.assertIn("ORDER BY date", read_sql.call_args.args[0])
+
+
+class StaticSafetyContractTest(unittest.TestCase):
+    def test_shell_python_and_yaml_syntax(self):
+        shells = [
+            "dump_qlib_bin.sh",
+            "upload_release.sh",
+            "daily_update.sh",
+            "ops/investment-data-project-monitor/collect_health.sh",
+            "ops/investment-data-project-monitor/deploy.sh",
+        ]
+        for relative in shells:
+            result = subprocess.run(["bash", "-n", str(ROOT / relative)], capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0, f"{relative}: {result.stderr}")
+        for relative in (
+            "qlib/normalize.py",
+            "qlib/dump_index_weight.py",
+            "qlib/validate_archive.py",
+            "tushare/dump_day_calendar.py",
+        ):
+            compile((ROOT / relative).read_text(), relative, "exec")
+        try:
+            import yaml
+        except ImportError:
+            yaml = None
+        if yaml:
+            for path in (ROOT / ".github/workflows").glob("*.yml"):
+                yaml.load(path.read_text(), Loader=yaml.BaseLoader)
+
+    def test_workflow_authority_pins_and_shared_lock(self):
+        upload = (ROOT / ".github/workflows/upload_release.yml").read_text()
+        data = (ROOT / ".github/workflows/data_update.yml").read_text()
+        image = (ROOT / ".github/workflows/docker-image.yml").read_text()
+        dockerfile = (ROOT / "Dockerfile").read_text()
+        self.assertEqual(upload.count("group: investment-data-dolt-volume"), 1)
+        self.assertEqual(data.count("group: investment-data-dolt-volume"), 1)
+        self.assertNotIn("CHECK_FRESHNESS", upload)
+        self.assertNotIn("svenstaro/upload-release-action", upload)
+        self.assertIn("permissions:\n      contents: write", upload)
+        self.assertIn("GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}", upload)
+        self.assertIn('"chenditc/investment_data@${PUBLICATION_IMAGE_DIGEST}"', upload)
+        self.assertNotIn("chenditc/investment_data:latest", upload)
+        self.assertIn("sha-${{ github.sha }}", image)
+        self.assertIn("INVESTMENT_DATA_REVISION=${{ github.sha }}", image)
+        self.assertIn(QLIB_COMMIT, dockerfile)
+        self.assertIn("org.opencontainers.image.revision", dockerfile)
+        self.assertIn("/opt/investment-data/REVISION", dockerfile)
+        self.assertNotIn("git pull https://github.com/chenditc/investment_data.git", dockerfile)
+
+    def test_upload_workflow_dispatch_shape(self):
+        import yaml
+
+        document = yaml.load(
+            (ROOT / ".github/workflows/upload_release.yml").read_text(),
+            Loader=yaml.BaseLoader,
+        )
+        operation = document["on"]["workflow_dispatch"]["inputs"]["operation"]
+        self.assertEqual(operation["required"], "true")
+        self.assertEqual(operation["type"], "choice")
+        self.assertEqual(operation["default"], "publish")
+        self.assertEqual(operation["options"], ["publish", "repair-2026-07-20"])
+
+    def test_dump_and_uploader_public_grammars_fail_before_work(self):
+        dump = subprocess.run(["bash", str(ROOT / "dump_qlib_bin.sh"), "a", "b", "c"], text=True, capture_output=True)
+        self.assertEqual(dump.returncode, 2)
+        publisher = subprocess.run(["bash", str(ROOT / "upload_release.sh"), "other"], text=True, capture_output=True)
+        self.assertEqual(publisher.returncode, 2)
+        self.assertEqual(publisher.stdout, "")
+        collector = subprocess.run(
+            ["bash", str(ROOT / "ops/investment-data-project-monitor/collect_health.sh"), "extra"],
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(collector.returncode, 2)
+        self.assertEqual(collector.stdout, "")
+
+    def _run_publisher_preflight_case(
+        self, *, field=None, value=None, arguments=(), forbidden=None
+    ):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            side_effect_sentinel = root / "network-or-mutation-called"
+            for command in ("curl", "dolt", "git"):
+                executable = bin_dir / command
+                executable.write_text(
+                    "#!/usr/bin/env bash\n"
+                    'printf called >"$SIDE_EFFECT_SENTINEL"\n'
+                    "exit 99\n",
+                    encoding="utf-8",
+                )
+                os.chmod(executable, 0o755)
+
+            repository_revision = root / "revision"
+            qlib_revision = root / "qlib-revision"
+            publisher_lock = root / "publisher.lock"
+            repository_revision.write_text("0" * 40 + "\n", encoding="utf-8")
+            qlib_revision.write_text(QLIB_COMMIT + "\n", encoding="utf-8")
+            env = {
+                "PATH": f"{bin_dir}:/usr/bin:/bin",
+                "SIDE_EFFECT_SENTINEL": str(side_effect_sentinel),
+                "GITHUB_ACTIONS": "true",
+                "GITHUB_EVENT_NAME": "workflow_dispatch",
+                "GITHUB_REPOSITORY": "chenditc/investment_data",
+                "GITHUB_REF": "refs/heads/main",
+                "GITHUB_SHA": "0" * 40,
+                "GITHUB_RUN_ID": "1",
+                "GITHUB_RUN_ATTEMPT": "1",
+                "GITHUB_TOKEN": "unused-test-token",
+                "PUBLICATION_IMAGE_DIGEST": "sha256:" + "a" * 64,
+                "PUBLICATION_BAKED_REPOSITORY_REVISION": "0" * 40,
+                "PUBLICATION_BAKED_QLIB_REVISION": QLIB_COMMIT,
+            }
+            if field is not None:
+                if value is None:
+                    env.pop(field)
+                else:
+                    env[field] = value
+            if forbidden is not None:
+                env[forbidden] = ""
+
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    (
+                        'source "$1"; shift; '
+                        'REPOSITORY_REVISION_FILE=$1; QLIB_REVISION_FILE=$2; '
+                        'PUBLISHER_LOCK=$3; shift 3; main "$@"'
+                    ),
+                    "bash",
+                    str(ROOT / "upload_release.sh"),
+                    str(repository_revision),
+                    str(qlib_revision),
+                    str(publisher_lock),
+                    *arguments,
+                ],
+                text=True,
+                capture_output=True,
+                env=env,
+            )
+            return (
+                result,
+                side_effect_sentinel.exists(),
+                publisher_lock.exists(),
+            )
+
+    def test_valid_publisher_grammar_rejects_bad_authority_before_network(self):
+        cases = (
+            ((), "GITHUB_ACTIONS", None, "publisher requires GitHub Actions authority"),
+            ((), "GITHUB_ACTIONS", "false", "publisher requires GitHub Actions authority"),
+            ((), "GITHUB_EVENT_NAME", "pull_request", "publish requires schedule or workflow_dispatch"),
+            ((), "GITHUB_REPOSITORY", "someone/else", "unexpected GitHub repository"),
+            ((), "GITHUB_REF", "refs/heads/feature", "publisher requires main branch authority"),
+            ((), "GITHUB_SHA", "A" * 40, "invalid GitHub commit authority"),
+            ((), "GITHUB_RUN_ID", "0", "invalid GitHub run ID"),
+            ((), "GITHUB_RUN_ATTEMPT", "x", "invalid GitHub run attempt"),
+            ((), "GITHUB_TOKEN", None, "GITHUB_TOKEN is required"),
+            ((), "PUBLICATION_IMAGE_DIGEST", "sha256:" + "A" * 64, "invalid image digest authority"),
+            ((), "PUBLICATION_BAKED_REPOSITORY_REVISION", "1" * 40, "launcher repository revision mismatch"),
+            ((), "PUBLICATION_BAKED_QLIB_REVISION", "1" * 40, "launcher qlib revision mismatch"),
+            (("repair-2026-07-20",), "GITHUB_EVENT_NAME", "schedule", "repair requires workflow_dispatch"),
+        )
+        for arguments, key, value, expected_error in cases:
+            with self.subTest(arguments=arguments, key=key):
+                result, side_effect_called, lock_created = self._run_publisher_preflight_case(
+                    field=key, value=value, arguments=arguments
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, "")
+                self.assertEqual(result.stderr, f"Error: {expected_error}\n")
+                self.assertFalse(side_effect_called)
+                self.assertFalse(lock_created)
+
+    def test_forbidden_publisher_environment_is_rejected_before_network_even_when_empty(self):
+        forbidden = (
+            "QLIB_BUILD_ID",
+            "QLIB_BUILD_ROOT",
+            "CLEAN_QLIB_BUILD_ROOT",
+            "CHECK_FRESHNESS",
+            "REPO",
+            "DATE",
+            "UPLOAD_RELEASE_LOCK_FILE",
+        )
+        for variable in forbidden:
+            with self.subTest(variable=variable):
+                result, side_effect_called, lock_created = self._run_publisher_preflight_case(
+                    forbidden=variable
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, "")
+                self.assertEqual(
+                    result.stderr,
+                    f"Error: {variable} is not a supported publisher input\n",
+                )
+                self.assertFalse(side_effect_called)
+                self.assertFalse(lock_created)
+
+    def test_publisher_lock_missing_open_and_contention_fail_before_build_or_api(self):
+        for failure in ("missing-support", "open-failure", "contention"):
+            with self.subTest(failure=failure):
+                body = r'''
+                  WORK_DIR=$1; SOURCE_FILE=$2
+                  GITHUB_ACTIONS=true
+                  GITHUB_EVENT_NAME=workflow_dispatch
+                  GITHUB_REPOSITORY=chenditc/investment_data
+                  GITHUB_REF=refs/heads/main
+                  GITHUB_SHA=$(printf '0%.0s' {1..40})
+                  GITHUB_RUN_ID=1
+                  GITHUB_RUN_ATTEMPT=1
+                  GITHUB_TOKEN=test-token
+                  PUBLICATION_IMAGE_DIGEST="sha256:$(printf 'a%.0s' {1..64})"
+                  PUBLICATION_BAKED_REPOSITORY_REVISION=$GITHUB_SHA
+                  PUBLICATION_BAKED_QLIB_REVISION=$QLIB_COMMIT
+                  REPOSITORY_REVISION_FILE="$WORK_DIR/revision"
+                  QLIB_REVISION_FILE="$WORK_DIR/qlib-revision"
+                  printf '%s\n' "$GITHUB_SHA" >"$REPOSITORY_REVISION_FILE"
+                  printf '%s\n' "$QLIB_COMMIT" >"$QLIB_REVISION_FILE"
+                  build_pair() { : >"$WORK_DIR/build-called"; }
+                  github_api_get() { : >"$WORK_DIR/api-called"; }
+                  case FAILURE in
+                    missing-support)
+                      eval "$(declare -f require_command | sed '1s/require_command/original_require_command/')"
+                      require_command() { [[ "$1" != flock ]] && original_require_command "$1"; }
+                      ;;
+                    open-failure)
+                      PUBLISHER_LOCK="$WORK_DIR/absent/lock"
+                      ;;
+                    contention)
+                      PUBLISHER_LOCK="$WORK_DIR/publisher.lock"
+                      flock() { return 1; }
+                      ;;
+                  esac
+                  if preflight publish; then
+                    build_pair
+                    github_api_get
+                    exit 97
+                  fi
+                  [[ ! -e "$WORK_DIR/build-called" && ! -e "$WORK_DIR/api-called" ]]
+                '''.replace("FAILURE", failure)
+                with tempfile.TemporaryDirectory() as temporary:
+                    work = Path(temporary)
+                    source = work / "source"
+                    source.write_bytes(b"unused")
+                    result = subprocess.run(
+                        [
+                            "bash",
+                            "-c",
+                            'source "$1"; shift; ' + body,
+                            "bash",
+                            str(ROOT / "upload_release.sh"),
+                            str(work),
+                            str(source),
+                        ],
+                        text=True,
+                        capture_output=True,
+                    )
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_daily_update_shared_lock_controls_dolt_mutation_behaviorally(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            dolt_dir = root / "dolt"
+            (dolt_dir / "investment_data").mkdir(parents=True)
+            script = root / "daily_update.sh"
+            script.write_text(
+                (ROOT / "daily_update.sh")
+                .read_text(encoding="utf-8")
+                .replace('DOLT_DIR="/dolt"', f'DOLT_DIR="{dolt_dir}"', 1),
+                encoding="utf-8",
+            )
+            os.chmod(script, 0o755)
+
+            def write_executable(directory, name, body):
+                path = directory / name
+                path.write_text("#!/bin/bash\n" + body, encoding="utf-8")
+                os.chmod(path, 0o755)
+
+            def run_case(case):
+                bin_dir = root / f"bin-{case}"
+                bin_dir.mkdir()
+                sentinel = root / f"mutation-{case}"
+                if case != "missing-flock":
+                    write_executable(
+                        bin_dir,
+                        "flock",
+                        "exit 1\n" if case == "contended" else "exit 0\n",
+                    )
+                write_executable(
+                    bin_dir,
+                    "dolt",
+                    (
+                        'if [[ "$1" == fetch ]]; then : >"$MUTATION_SENTINEL"; fi\n'
+                        'if [[ "$1" == status ]]; then '
+                        "printf '%s\\n' 'nothing to commit, working tree clean'; fi\n"
+                        'if [[ "$1" == sql && "$*" == *"MIN(index_max_date)"* ]]; then '
+                        "printf '%s\\n' '20260721'; fi\n"
+                        "exit 0\n"
+                    ),
+                )
+                for name in ("python3", "killall", "sleep", "ls"):
+                    write_executable(bin_dir, name, "exit 0\n")
+                (bin_dir / "mkdir").symlink_to("/usr/bin/mkdir")
+                (bin_dir / "tail").symlink_to("/usr/bin/tail")
+                return subprocess.run(
+                    ["/bin/bash", str(script)],
+                    text=True,
+                    capture_output=True,
+                    env={
+                        "PATH": str(bin_dir),
+                        "MUTATION_SENTINEL": str(sentinel),
+                    },
+                ), sentinel.exists()
+
+            acquired, acquired_mutation = run_case("acquired")
+            self.assertEqual(acquired.returncode, 0, acquired.stderr)
+            self.assertTrue(acquired_mutation)
+
+            for case, expected_error in (
+                ("missing-flock", "flock is required"),
+                ("contended", "shared Dolt checkout is locked"),
+            ):
+                with self.subTest(case=case):
+                    result, mutation_called = run_case(case)
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(expected_error, result.stderr)
+                    self.assertFalse(mutation_called)
+
+    def _run_stubbed_standalone_dump(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        working = root / "working"
+        investment_data = working / "investment_data"
+        shared_dolt = working / "dolt/investment_data"
+        qlib_checkout = working / "qlib"
+        caller = root / "caller"
+        supplied_repository = root / "supplied-qlib.git"
+        bin_dir = root / "bin"
+        for path in (
+            investment_data / ".git",
+            shared_dolt / ".dolt",
+            qlib_checkout / ".git",
+            caller,
+            supplied_repository,
+            bin_dir,
+        ):
+            path.mkdir(parents=True)
+        wrong_origin = "https://example.invalid/wrong-origin.git"
+        (qlib_checkout / ".git/origin-url").write_text(
+            wrong_origin + "\n", encoding="utf-8"
+        )
+        git_log = root / "git.log"
+
+        def write_executable(name, body):
+            path = bin_dir / name
+            path.write_text("#!/usr/bin/env bash\n" + body, encoding="utf-8")
+            os.chmod(path, 0o755)
+
+        write_executable(
+            "git",
+            r'''printf '%s\n' "$*" >>"$QLIB_GIT_LOG"
+if [[ "$1" == -C && "$3" == fetch ]]; then
+  [[ "$2" == "$QLIB_CHECKOUT" ]]
+  [[ "$4" == "$EXPECTED_QLIB_REPOSITORY" ]]
+  [[ "$5" == "$EXPECTED_QLIB_COMMIT" ]]
+  exit
+fi
+if [[ "$1" == -C && "$3" == rev-parse ]]; then
+  if [[ "$2" == "$QLIB_CHECKOUT" ]]; then
+    printf '%s\n' "$EXPECTED_QLIB_COMMIT"
+  else
+    printf '0%.0s' {1..40}; printf '\n'
+  fi
+  exit
+fi
+exit 0
+''',
+        )
+        write_executable(
+            "dolt",
+            r'''case "$1" in
+  status) printf '%s\n' 'nothing to commit, working tree clean' ;;
+  sql) printf '%s\n' value '9vtplc2tar9ver7p6s1bus2oiedjvtqo' ;;
+  sql-server) trap 'exit 0' TERM; while :; do /bin/sleep 1; done ;;
+esac
+exit 0
+''',
+        )
+        write_executable("flock", "exit 0\n")
+        write_executable(
+            "python3",
+            r'''if [[ -n "${DOLT_QUERY:-}" ]]; then
+  case "$DOLT_QUERY" in
+    *"SELECT 1"*) printf '%s\n' 1 ;;
+    *"DOLT_HASHOF"*) printf '%s\n' '9vtplc2tar9ver7p6s1bus2oiedjvtqo' ;;
+    *"MIN(date)"*) printf '%s\n' '2026-07-22' ;;
+    *"MAX(tradedate)"*) printf '%s\n' '2026-07-21' ;;
+    *"date <="*) printf '%s\n' '2026-07-21' ;;
+    *"MAX(date)"*) printf '%s\n' '2026-12-31' ;;
+  esac
+  exit 0
+fi
+if [[ -n "${MANIFEST_PATH:-}" ]]; then
+  printf '%s\n' '{"stub":true}' >"$MANIFEST_PATH"
+  exit 0
+fi
+arguments="$*"
+if [[ "$arguments" == *dump_bin.py* ]]; then
+  while (($#)); do
+    if [[ "$1" == --qlib_dir ]]; then shift; qlib_dir=$1; break; fi
+    shift
+  done
+  mkdir -p "$qlib_dir/calendars" "$qlib_dir/instruments"
+  printf '%s\n' '2026-07-21' >"$qlib_dir/calendars/day.txt"
+  printf '%s\n' $'SH600000\t2026-07-21\t2026-07-21' >"$qlib_dir/instruments/all.txt"
+elif [[ "$arguments" == *dump_index_weight.py* ]]; then
+  mkdir -p "$QLIB_INDEX_DIR"
+  for name in csi300 csi500 csi800 csi1000 csiall; do
+    printf '%s\n' $'SH600000\t2026-07-21\t2026-07-21' >"$QLIB_INDEX_DIR/$name.txt"
+  done
+elif [[ "$arguments" == *dump_day_calendar.py* ]]; then
+  qlib_dir=$2
+  mkdir -p "$qlib_dir/calendars"
+  printf '%s\n' '2026-07-21' '2026-07-22' '2026-12-31' >"$qlib_dir/calendars/day_future.txt"
+fi
+exit 0
+''',
+        )
+
+        env = {
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "QLIB_GIT_LOG": str(git_log),
+            "QLIB_CHECKOUT": str(qlib_checkout),
+            "EXPECTED_QLIB_REPOSITORY": str(supplied_repository),
+            "EXPECTED_QLIB_COMMIT": QLIB_COMMIT,
+        }
+        result = subprocess.run(
+            [
+                "/bin/bash",
+                str(ROOT / "dump_qlib_bin.sh"),
+                str(working),
+                str(supplied_repository),
+            ],
+            cwd=caller,
+            text=True,
+            capture_output=True,
+            env=env,
+        )
+        return {
+            "result": result,
+            "git_log": git_log.read_text(encoding="utf-8") if git_log.exists() else "",
+            "wrong_origin": wrong_origin,
+            "supplied_repository": str(supplied_repository),
+            "investment_data": investment_data,
+            "caller": caller,
+        }
+
+    def test_dump_fetches_pin_from_supplied_repository_for_preexisting_checkout(self):
+        evidence = self._run_stubbed_standalone_dump()
+        result = evidence["result"]
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            f"fetch {evidence['supplied_repository']} {QLIB_COMMIT}",
+            evidence["git_log"],
+        )
+        self.assertNotIn(
+            f"fetch origin {QLIB_COMMIT}",
+            evidence["git_log"],
+        )
+        self.assertNotEqual(evidence["wrong_origin"], evidence["supplied_repository"])
+
+    def test_dump_fallback_places_pair_in_repository_not_invocation_directory(self):
+        evidence = self._run_stubbed_standalone_dump()
+        result = evidence["result"]
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for name in ("qlib_bin.tar.gz", "qlib_bin.manifest.json"):
+            with self.subTest(name=name):
+                self.assertTrue((evidence["investment_data"] / name).is_file())
+                self.assertFalse((evidence["caller"] / name).exists())
+
+    def test_generator_bounds_order_and_fire_contract(self):
+        index = (ROOT / "qlib/dump_index_weight.py").read_text()
+        calendar = (ROOT / "tushare/dump_day_calendar.py").read_text()
+        normalize = (ROOT / "qlib/normalize.py").read_text()
+        dump = (ROOT / "dump_qlib_bin.sh").read_text()
+        self.assertIn("target_trade_date: Optional[str] = None", index)
+        self.assertIn("GROUP_CONCAT(stock_code ORDER BY stock_code SEPARATOR ',')", index)
+        self.assertIn("ORDER BY stock_code", index)
+        self.assertIn("rows.sort(key=lambda row: (row[0], row[1], row[2]))", index)
+        self.assertIn("target_trade_date: Optional[str] = None", calendar)
+        self.assertIn("ORDER BY date", calendar)
+        self.assertIn('filename.open("w", encoding="utf-8", newline="\\n")', index)
+        self.assertIn('filename.open("w", encoding="utf-8", newline="\\n")', calendar)
+        self.assertNotIn("write_text(", index)
+        self.assertNotIn("write_text(", calendar)
+        self.assertIn("target_trade_date=None", normalize)
+        self.assertIn("_DateFieldAwareNormalize", normalize)
+        self.assertIn('--data_path "$QLIB_NORMALIZE_DIR"', dump)
+        self.assertNotIn("dump_bin_help", dump)
+        self.assertNotIn("--csv_path", dump)
+
+    def test_dolt_identities_use_machine_readable_hash_queries(self):
+        dump = (ROOT / "dump_qlib_bin.sh").read_text()
+        uploader = (ROOT / "upload_release.sh").read_text()
+        self.assertIn("DOLT_HASHOF('origin/master')", dump)
+        self.assertIn("DOLT_HASHOF('HEAD')", dump)
+        self.assertIn("DOLT_HASHOF('origin/master')", uploader)
+        self.assertNotIn("dolt log -n 1", dump)
+        self.assertNotIn("dolt log -n 1", uploader)
+        self.assertIn('pymysql.connect(', dump)
+        self.assertIn('query_scalar "SELECT 1"', dump)
+        self.assertIn('kill -0 "$DOLT_SQL_SERVER_PID"', dump)
+
+    def test_invalid_generator_targets_fail_before_database_connection(self):
+        fire = types.ModuleType("fire")
+        fire.Fire = lambda *_args, **_kwargs: None
+        with mock.patch.dict(sys.modules, {"fire": fire}):
+            for relative, function in (
+                ("qlib/dump_index_weight.py", "dump_all_to_sqlib_source"),
+                ("tushare/dump_day_calendar.py", "dump_calendar_to_qlib_dir"),
+            ):
+                spec = importlib.util.spec_from_file_location(function + "_module", ROOT / relative)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                with mock.patch.object(module, "create_engine") as create:
+                    with self.assertRaises(ValueError):
+                        kwargs = {"target_trade_date": "2026-7-20"}
+                        if function == "dump_calendar_to_qlib_dir":
+                            kwargs["qlib_dir"] = "unused"
+                        getattr(module, function)(**kwargs)
+                    create.assert_not_called()
+
+    def test_publisher_fixed_repair_and_lock_are_literal_and_narrow(self):
+        publisher = (ROOT / "upload_release.sh").read_text()
+        self.assertIn('PUBLISHER_LOCK="/tmp/investment-data-release-publisher.lock"', publisher)
+        self.assertIn('FIXED_DOLT_COMMIT="9vtplc2tar9ver7p6s1bus2oiedjvtqo"', publisher)
+        self.assertIn("FIXED_RELEASE_ID=356733573", publisher)
+        self.assertIn("FIXED_ORIGINAL_ASSET_ID=483488955", publisher)
+        self.assertIn('BACKUP_NAME="qlib_bin.original-2026-07-20-483488955.tar.gz"', publisher)
+        self.assertIn('RECEIPT_NAME="qlib-repair-2026-07-20.json"', publisher)
+        self.assertIn("recover_exact_starter", publisher)
+        self.assertIn("github_get_asset_by_id_optional", publisher)
+        self.assertNotIn("UPLOAD_RELEASE_LOCK_FILE:-", publisher)
+        self.assertNotIn("GITHUB_PAT", publisher)
+        self.assertNotIn("GH_TOKEN", publisher)
+
+    def test_documentation_uses_only_workflow_publication(self):
+        command = "gh workflow run upload_release.yml --repo chenditc/investment_data --ref main -f operation=publish"
+        for relative in (
+            "README.md",
+            "docs/README-ch.md",
+            "docs/final_a_stock_eod_price.md",
+            "docs/final_a_stock_eod_price.ch.md",
+        ):
+            text = (ROOT / relative).read_text()
+            self.assertIn(command, text, relative)
+            self.assertIn("qlib_bin.tar.gz", text, relative)
+            self.assertIn("qlib_bin.manifest.json", text, relative)
+            self.assertIn("validate_archive.py", text, relative)
+            self.assertNotIn("GITHUB_PAT", text, relative)
+
+        for relative in ("README.md", "docs/README-ch.md"):
+            text = (ROOT / relative).read_text()
+            self.assertNotIn("2023-10-08", text, relative)
+            self.assertEqual(text.count("<release-tag>"), 3, relative)
+        chinese = (ROOT / "docs/README-ch.md").read_text()
+        self.assertIn(
+            "tar -zxvf qlib_bin.tar.gz -C ~/.qlib/qlib_data/cn_data --strip-components=1",
+            chinese,
+        )
+
+    def test_operator_documents_contain_no_standalone_patch_marker_paragraphs(self):
+        for relative in (
+            "README.md",
+            "docs/README-ch.md",
+            "docs/final_a_stock_eod_price.md",
+            "docs/final_a_stock_eod_price.ch.md",
+            "ops/investment-data-project-monitor/SKILL.md",
+        ):
+            with self.subTest(relative=relative):
+                lines = (ROOT / relative).read_text(encoding="utf-8").splitlines()
+                self.assertNotIn("+", (line.strip() for line in lines))
+
+    def test_fail_safe_repository_rollback_is_ordered_and_impacts_are_bounded(self):
+        documents = (
+            "README.md",
+            "docs/README-ch.md",
+            "docs/final_a_stock_eod_price.md",
+            "docs/final_a_stock_eod_price.ch.md",
+            "ops/investment-data-project-monitor/SKILL.md",
+        )
+        disable = "gh workflow disable upload_release.yml --repo chenditc/investment_data"
+        query = (
+            "gh workflow view upload_release.yml --repo chenditc/investment_data "
+            "--json state --jq .state"
+        )
+        for relative in documents:
+            text = (ROOT / relative).read_text(encoding="utf-8")
+            with self.subTest(relative=relative):
+                disable_at = text.index(disable)
+                first_query = text.index(query, disable_at)
+                first_disabled = text.index("disabled_manually", first_query)
+                drain = text.index("data_update.yml", first_disabled)
+                second_query = text.index(query, drain)
+                second_disabled = text.index("disabled_manually", second_query)
+                self.assertLess(
+                    disable_at,
+                    first_query,
+                )
+                self.assertLess(first_query, first_disabled)
+                self.assertLess(first_disabled, drain)
+                self.assertLess(drain, second_query)
+                self.assertLess(second_query, second_disabled)
+                for required in (
+                    "latest",
+                    "repair-2026-07-20",
+                    "concurrency",
+                    "backup",
+                    "deploy.sh rollback",
+                ):
+                    self.assertIn(required, text)
+
+        workflow_state = "active"
+        events = []
+        release_mutations = []
+        monitor_mutations = []
+
+        def disable_upload():
+            nonlocal workflow_state
+            events.append("disable")
+            workflow_state = "disabled_manually"
+
+        def require_disabled(label):
+            events.append(label)
+            self.assertEqual(workflow_state, "disabled_manually")
+
+        def drain_shared_volume_jobs():
+            events.append("drain-upload-and-data-update")
+
+        def full_revert():
+            events.append("full-revert")
+
+        disable_upload()
+        require_disabled("query-before-revert")
+        drain_shared_volume_jobs()
+        full_revert()
+        require_disabled("query-after-revert")
+        events.append("remain-disabled-until-safety-restored")
+        self.assertEqual(
+            events,
+            [
+                "disable",
+                "query-before-revert",
+                "drain-upload-and-data-update",
+                "full-revert",
+                "query-after-revert",
+                "remain-disabled-until-safety-restored",
+            ],
+        )
+        self.assertEqual(release_mutations, [])
+        self.assertEqual(monitor_mutations, [])
+
+    def test_collector_and_deployer_contracts_are_archive_aware_and_physical(self):
+        collector = (ROOT / "ops/investment-data-project-monitor/collect_health.sh").read_text()
+        deploy = (ROOT / "ops/investment-data-project-monitor/deploy.sh").read_text()
+        guide = (ROOT / "ops/investment-data-project-monitor/SKILL.md").read_text()
+        self.assertIn("release.archive_validation", guide)
+        self.assertIn("archive_validation:$archive_validation", collector)
+        self.assertIn("--require-publishable", collector)
+        self.assertIn(".claude/skills-own/investment-data-project-monitor", deploy)
+        self.assertIn(".investment-data-project-monitor.rollback-148", deploy)
+        self.assertIn(COMPATIBILITY_LINK_TARGET, deploy)
+        self.assertIn('verify_inventory "$backup" false', deploy)
+        self.assertIn(
+            'AUTHORIZED_OLD_SKILL_SHA256="0ec01463ab825502d6599d8c5f236bd56a9a0b2fdb76156fc5d997c04dbb9bbc"',
+            deploy,
+        )
+        self.assertIn(
+            'AUTHORIZED_OLD_COLLECTOR_SHA256="f2b6d97b18f2f5cf5b902c1a78f5043c1659ada6659ffb7105454dd84e3057b6"',
+            deploy,
+        )
+        self.assertIn(
+            'AUTHORIZED_NOTIFIER_SHA256="bda57d27128637c6dd7139fe8825205c957483400b063c02f48fcf209d294224"',
+            deploy,
+        )
+        self.assertNotIn("backup_has_validator", deploy)
+        self.assertNotIn(".local/share", deploy)
+        self.assertNotIn("cp -p \"$source", collector)
+        self.assertNotIn("notify_feishu.sh.next", deploy)
+
+
+class PublisherStateSimulationTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.source = self.root / "asset.bin"
+        self.source.write_bytes(b"validated immutable bytes")
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def run_bash(self, body):
+        return subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$1"; shift; ' + body,
+                "bash",
+                str(ROOT / "upload_release.sh"),
+                str(self.root),
+                str(self.source),
+            ],
+            text=True,
+            capture_output=True,
+        )
+
+    def run_stateful_publisher(
+        self,
+        operation,
+        archive,
+        manifest,
+        original,
+        failure_boundary="",
+        failure_timing="",
+    ):
+        body = r'''
+          source "$1"; shift
+          HARNESS_ROOT=$1; FIXTURE_ARCHIVE=$2; FIXTURE_MANIFEST=$3
+          ORIGINAL_FILE=$4; VALIDATOR=$5; OPERATION=$6
+          FAILURE_BOUNDARY=$7; FAILURE_TIMING=$8
+          STATE_FILE="$HARNESS_ROOT/state.json"
+          REMOTE_DIR="$HARNESS_ROOT/remote"
+          EVENT_LOG="$HARNESS_ROOT/events.log"
+          NEXT_ID_FILE="$HARNESS_ROOT/next-id"
+          WORK_DIR="$HARNESS_ROOT/work"
+          mkdir -p "$REMOTE_DIR" "$WORK_DIR"
+
+          GITHUB_SHA=$(printf '0%.0s' {1..40})
+          PUBLICATION_IMAGE_DIGEST="sha256:$(printf 'a%.0s' {1..64})"
+          ORIGIN_AUTHORITY_VERIFIED=true
+          FIXED_ORIGINAL_SIZE=$(file_size "$ORIGINAL_FILE")
+          FIXED_ORIGINAL_DIGEST=$(sha256_file "$ORIGINAL_FILE")
+
+          log_event() { printf '%s\n' "$1" >>"$EVENT_LOG"; }
+          date() {
+            if [[ "$*" == "+%F" ]]; then
+              printf '%s\n' '2026-07-20'
+            else
+              command date "$@"
+            fi
+          }
+          select_normal_dolt_commit() {
+            log_event select-dolt
+            printf '%s\n' '9vtplc2tar9ver7p6s1bus2oiedjvtqo'
+          }
+          validate_pair() {
+            log_event "validate:$(basename "$1"):$(basename "$2")"
+            python3 "$VALIDATOR" --archive "$1" --manifest "$2" \
+              --expected-tag "$3" --require-publishable >/dev/null
+          }
+          build_pair() {
+            local tag=$1 dolt_commit=$2 output_dir=$3
+            [[ "$tag" == 2026-07-20 && "$dolt_commit" == 9vtplc2tar9ver7p6s1bus2oiedjvtqo ]]
+            mkdir -p "$output_dir"
+            cp "$FIXTURE_ARCHIVE" "$output_dir/$ARCHIVE_NAME"
+            cp "$FIXTURE_MANIFEST" "$output_dir/$MANIFEST_NAME"
+            validate_pair "$output_dir/$ARCHIVE_NAME" "$output_dir/$MANIFEST_NAME" "$tag"
+          }
+          github_get_release_by_tag_optional() {
+            log_event release:get-normal
+            printf '%s\n' '{"id":42,"tag_name":"2026-07-20","draft":false,"prerelease":false}'
+          }
+          github_create_release() {
+            log_event release:create
+            return 99
+          }
+          github_api_get() {
+            log_event release:get-fixed
+            printf '%s\n' '{"id":356733573,"tag_name":"2026-07-20","draft":false,"prerelease":false}'
+          }
+          list_assets() { cat "$STATE_FILE"; }
+          github_upload_asset() {
+            local release_id=$1 name=$2 path=$3 content_type=$4 id size digest asset temporary
+            [[ "$release_id" == "$RELEASE_ID" && -n "$content_type" ]]
+            if [[ "$name" == "$FAILURE_BOUNDARY" && ! -e "$HARNESS_ROOT/injected" ]]; then
+              : >"$HARNESS_ROOT/injected"
+              if [[ "$FAILURE_TIMING" == before ]]; then
+                log_event "injected-before:$name"
+                exit 77
+              elif [[ "$FAILURE_TIMING" == starter ]]; then
+                id=$(cat "$NEXT_ID_FILE")
+                printf '%s\n' "$((id + 1))" >"$NEXT_ID_FILE"
+                asset=$(jq -cn --argjson id "$id" --arg name "$name" \
+                  '{id:$id,name:$name,state:"starter",size:0,digest:null,created_at:"2026-07-21T12:00:00Z",updated_at:"2026-07-21T12:00:00Z"}')
+                temporary="$STATE_FILE.next"
+                jq --argjson asset "$asset" '. + [$asset]' "$STATE_FILE" >"$temporary"
+                mv "$temporary" "$STATE_FILE"
+                log_event "starter:$name:$id"
+                return 77
+              fi
+            fi
+            id=$(cat "$NEXT_ID_FILE")
+            printf '%s\n' "$((id + 1))" >"$NEXT_ID_FILE"
+            size=$(file_size "$path")
+            digest=$(sha256_file "$path")
+            asset=$(jq -cn --argjson id "$id" --arg name "$name" --argjson size "$size" \
+              --arg digest "$digest" \
+              '{id:$id,name:$name,state:"uploaded",size:$size,digest:$digest,created_at:"2026-07-21T12:00:00Z",updated_at:"2026-07-21T12:00:01Z"}')
+            temporary="$STATE_FILE.next"
+            jq --argjson asset "$asset" '. + [$asset]' "$STATE_FILE" >"$temporary"
+            mv "$temporary" "$STATE_FILE"
+            cp "$path" "$REMOTE_DIR/$id"
+            log_event "upload:$name:$id"
+            if [[ "$name" == "$FAILURE_BOUNDARY" && "$FAILURE_TIMING" == after \
+                && -e "$HARNESS_ROOT/injected" && ! -e "$HARNESS_ROOT/after-exited" ]]; then
+              : >"$HARNESS_ROOT/after-exited"
+              exit 77
+            fi
+            if [[ "$name" == "$FAILURE_BOUNDARY" && "$FAILURE_TIMING" == lost \
+                && -e "$HARNESS_ROOT/injected" && ! -e "$HARNESS_ROOT/lost-returned" ]]; then
+              : >"$HARNESS_ROOT/lost-returned"
+              return 77
+            fi
+            printf '%s\n' "$asset"
+          }
+          github_download_asset() {
+            local id=$1 destination=$2 asset name
+            asset=$(jq -c --argjson id "$id" '.[] | select(.id == $id)' "$STATE_FILE")
+            [[ -n "$asset" ]]
+            name=$(jq -r '.name' <<<"$asset")
+            cp "$REMOTE_DIR/$id" "$destination"
+            log_event "download:$name:$id"
+          }
+          github_delete_asset() {
+            local id=$1 name temporary
+            name=$(jq -r --argjson id "$id" '.[] | select(.id == $id) | .name' "$STATE_FILE")
+            [[ -n "$name" ]]
+            temporary="$STATE_FILE.next"
+            jq --argjson id "$id" '[.[] | select(.id != $id)]' "$STATE_FILE" >"$temporary"
+            mv "$temporary" "$STATE_FILE"
+            rm -f -- "$REMOTE_DIR/$id"
+            log_event "delete:$name:$id"
+            if [[ "$FAILURE_BOUNDARY" == original-delete \
+                && "$id" == "$FIXED_ORIGINAL_ASSET_ID" \
+                && "$FAILURE_TIMING" == lost && ! -e "$HARNESS_ROOT/delete-lost" ]]; then
+              : >"$HARNESS_ROOT/delete-lost"
+              return 77
+            fi
+          }
+          github_get_asset_by_id_optional() {
+            local asset
+            asset=$(jq -c --argjson id "$1" '[.[] | select(.id == $id)] | if length == 1 then .[0] else null end' "$STATE_FILE")
+            if [[ "$asset" == null ]]; then
+              return 4
+            fi
+            printf '%s\n' "$asset"
+          }
+
+          if [[ "$FAILURE_BOUNDARY" == original-delete \
+              && ( "$FAILURE_TIMING" == before || "$FAILURE_TIMING" == after ) ]]; then
+            eval "$(declare -f delete_original_after_gate \
+              | sed '1s/delete_original_after_gate/original_delete_original_after_gate/')"
+            delete_original_after_gate() {
+              if [[ "$FAILURE_TIMING" == before && ! -e "$HARNESS_ROOT/delete-before" ]]; then
+                : >"$HARNESS_ROOT/delete-before"
+                log_event injected-failure-before-original-delete
+                exit 77
+              fi
+              original_delete_original_after_gate || return 1
+              if [[ "$FAILURE_TIMING" == after && ! -e "$HARNESS_ROOT/delete-after" ]]; then
+                : >"$HARNESS_ROOT/delete-after"
+                log_event injected-failure-after-original-delete
+                exit 77
+              fi
+            }
+          fi
+
+          if [[ "$OPERATION" == publish ]]; then
+            publish_current
+          else
+            repair_fixed_release
+          fi
+        '''
+        return subprocess.run(
+            [
+                "bash",
+                "-c",
+                body,
+                "bash",
+                str(ROOT / "upload_release.sh"),
+                str(self.root),
+                str(archive),
+                str(manifest),
+                str(original),
+                str(VALIDATOR),
+                operation,
+                failure_boundary,
+                failure_timing,
+            ],
+            text=True,
+            capture_output=True,
+        )
+
+    def remote_bytes(self, state, name):
+        asset = next(item for item in state if item["name"] == name)
+        return (self.root / "remote" / str(asset["id"])).read_bytes()
+
+    def reset_stateful_repair(self, original):
+        for name in (
+            "remote",
+            "work",
+            "events.log",
+            "state.json",
+            "next-id",
+            "injected",
+            "after-exited",
+            "lost-returned",
+            "delete-before",
+            "delete-after",
+            "delete-lost",
+        ):
+            path = self.root / name
+            if path.is_dir() and not path.is_symlink():
+                shutil.rmtree(path)
+            elif path.exists() or path.is_symlink():
+                path.unlink()
+        original_asset = {
+            "id": 483488955,
+            "name": "qlib_bin.tar.gz",
+            "state": "uploaded",
+            "size": original.stat().st_size,
+            "digest": "sha256:" + hashlib.sha256(original.read_bytes()).hexdigest(),
+            "created_at": "2026-07-20T13:26:30Z",
+            "updated_at": "2026-07-20T13:26:48Z",
+        }
+        (self.root / "state.json").write_text(json.dumps([original_asset]) + "\n")
+        (self.root / "next-id").write_text("500000001\n")
+        remote = self.root / "remote"
+        remote.mkdir()
+        shutil.copy2(original, remote / "483488955")
+
+    def reset_stateful_publish(self):
+        for name in (
+            "remote",
+            "work",
+            "events.log",
+            "state.json",
+            "next-id",
+            "injected",
+            "after-exited",
+            "lost-returned",
+        ):
+            path = self.root / name
+            if path.is_dir() and not path.is_symlink():
+                shutil.rmtree(path)
+            elif path.exists() or path.is_symlink():
+                path.unlink()
+        (self.root / "state.json").write_text("[]\n")
+        (self.root / "next-id").write_text("100\n")
+
+    def repair_boundary_names(self, archive):
+        stem = (
+            "qlib_bin.repair-2026-07-20-"
+            + "0" * 40
+            + "-"
+            + "a" * 64
+            + "-"
+            + hashlib.sha256(archive.read_bytes()).hexdigest()
+        )
+        return {
+            "candidate-archive": stem + ".tar.gz",
+            "candidate-manifest": stem + ".manifest.json",
+            "backup": "qlib_bin.original-2026-07-20-483488955.tar.gz",
+            "receipt": "qlib-repair-2026-07-20.json",
+            "original-delete": "original-delete",
+            "canonical-archive": "qlib_bin.tar.gz",
+            "canonical-manifest": "qlib_bin.manifest.json",
+        }
+
+    def assert_repair_accepted(self, archive, manifest, result):
+        self.assertEqual(result.returncode, 0, result.stderr)
+        state = json.loads((self.root / "state.json").read_text())
+        names = [asset["name"] for asset in state]
+        self.assertIn("qlib_bin.tar.gz", names)
+        self.assertIn("qlib_bin.manifest.json", names)
+        self.assertIn("qlib-repair-2026-07-20.json", names)
+        self.assertEqual(self.remote_bytes(state, "qlib_bin.tar.gz"), archive.read_bytes())
+        self.assertEqual(
+            self.remote_bytes(state, "qlib_bin.manifest.json"), manifest.read_bytes()
+        )
+
+    def test_lost_upload_starter_is_deleted_by_exact_id_then_retried(self):
+        state = self.root / "state.json"
+        state.write_text("[]\n")
+        (self.root / "uploads").write_text("0\n")
+        body = r'''
+          WORK_DIR=$1; SOURCE_FILE=$2; RELEASE_ID=42; ORIGIN_AUTHORITY_VERIFIED=true
+          STATE_FILE="$WORK_DIR/state.json"; DELETE_LOG="$WORK_DIR/delete.log"; UPLOADS="$WORK_DIR/uploads"
+          list_assets() { cat "$STATE_FILE"; }
+          github_upload_asset() {
+            local count size digest
+            count=$(($(cat "$UPLOADS") + 1)); printf '%s\n' "$count" >"$UPLOADS"
+            if [[ "$count" == 1 ]]; then
+              printf '%s\n' '[{"id":91,"name":"asset.bin","state":"starter","size":0,"digest":null}]' >"$STATE_FILE"
+              return 1
+            fi
+            size=$(file_size "$SOURCE_FILE"); digest=$(sha256_file "$SOURCE_FILE")
+            jq -cn --arg digest "$digest" --argjson size "$size" '[{id:92,name:"asset.bin",state:"uploaded",size:$size,digest:$digest}]' >"$STATE_FILE"
+          }
+          github_download_asset() { cp "$SOURCE_FILE" "$2"; }
+          github_delete_asset() { printf '%s\n' "$1" >>"$DELETE_LOG"; printf '%s\n' '[]' >"$STATE_FILE"; }
+          github_get_asset_by_id_optional() { return 4; }
+          ensure_uploaded_asset asset.bin "$SOURCE_FILE" application/octet-stream "$WORK_DIR/downloaded" >/dev/null
+          [[ "$(cat "$DELETE_LOG")" == 91 ]]
+          [[ "$(cat "$UPLOADS")" == 2 ]]
+          cmp -s "$SOURCE_FILE" "$WORK_DIR/downloaded"
+        '''
+        result = self.run_bash(body)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_nonzero_starter_after_failed_upload_is_not_deleted(self):
+        (self.root / "state.json").write_text("[]\n")
+        body = r'''
+          WORK_DIR=$1; SOURCE_FILE=$2; RELEASE_ID=42; ORIGIN_AUTHORITY_VERIFIED=true
+          STATE_FILE="$WORK_DIR/state.json"; DELETE_LOG="$WORK_DIR/delete.log"
+          list_assets() { cat "$STATE_FILE"; }
+          github_upload_asset() {
+            printf '%s\n' '[{"id":91,"name":"asset.bin","state":"starter","size":1,"digest":null}]' >"$STATE_FILE"
+            return 1
+          }
+          github_delete_asset() { printf '%s\n' "$1" >>"$DELETE_LOG"; }
+          github_get_asset_by_id_optional() { return 4; }
+          if ensure_uploaded_asset asset.bin "$SOURCE_FILE" application/octet-stream "$WORK_DIR/downloaded" \
+              >/dev/null 2>&1; then
+            exit 1
+          fi
+          [[ ! -e "$DELETE_LOG" ]]
+        '''
+        result = self.run_bash(body)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_same_invocation_zero_byte_starter_recovery_covers_all_upload_boundaries(self):
+        pair_root = self.root / "starter-pair"
+        pair_root.mkdir()
+        archive, manifest = build_pair(pair_root)
+        original = self.root / "starter-original.tar.gz"
+        original.write_bytes(b"captured original archive bytes")
+        repair_names = self.repair_boundary_names(archive)
+
+        for label, name in (
+            ("normal-archive", "qlib_bin.tar.gz"),
+            ("normal-manifest", "qlib_bin.manifest.json"),
+        ):
+            with self.subTest(boundary=label):
+                self.reset_stateful_publish()
+                result = self.run_stateful_publisher(
+                    "publish", archive, manifest, original, name, "starter"
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                events = (self.root / "events.log").read_text().splitlines()
+                starter = next(value for value in events if value.startswith(f"starter:{name}:"))
+                starter_id = starter.rsplit(":", 1)[1]
+                self.assertIn(f"delete:{name}:{starter_id}", events)
+
+        for label in (
+            "candidate-archive",
+            "candidate-manifest",
+            "backup",
+            "receipt",
+            "canonical-archive",
+            "canonical-manifest",
+        ):
+            with self.subTest(boundary=label):
+                self.reset_stateful_repair(original)
+                name = repair_names[label]
+                result = self.run_stateful_publisher(
+                    "repair", archive, manifest, original, name, "starter"
+                )
+                self.assert_repair_accepted(archive, manifest, result)
+                events = (self.root / "events.log").read_text().splitlines()
+                starter = next(value for value in events if value.startswith(f"starter:{name}:"))
+                starter_id = starter.rsplit(":", 1)[1]
+                self.assertIn(f"delete:{name}:{starter_id}", events)
+
+    def test_repair_before_after_and_lost_response_boundaries_all_reach_accepted(self):
+        pair_root = self.root / "boundary-pair"
+        pair_root.mkdir()
+        archive, manifest = build_pair(pair_root)
+        original = self.root / "boundary-original.tar.gz"
+        original.write_bytes(b"captured original archive bytes")
+        names = self.repair_boundary_names(archive)
+        boundaries = (
+            "candidate-archive",
+            "candidate-manifest",
+            "backup",
+            "receipt",
+            "original-delete",
+            "canonical-archive",
+            "canonical-manifest",
+        )
+        observed_uploaded_prefixes = set()
+        for boundary in boundaries:
+            for timing in ("before", "after", "lost"):
+                with self.subTest(boundary=boundary, timing=timing):
+                    self.reset_stateful_repair(original)
+                    interrupted = self.run_stateful_publisher(
+                        "repair",
+                        archive,
+                        manifest,
+                        original,
+                        names[boundary],
+                        timing,
+                    )
+                    if timing in ("before", "after"):
+                        self.assertNotEqual(interrupted.returncode, 0, interrupted.stderr)
+                        if timing == "after" and boundary in (
+                            "candidate-archive",
+                            "candidate-manifest",
+                            "backup",
+                            "receipt",
+                        ):
+                            observed_uploaded_prefixes.add(boundary)
+                        resumed = self.run_stateful_publisher(
+                            "repair", archive, manifest, original
+                        )
+                    else:
+                        resumed = interrupted
+                    self.assert_repair_accepted(archive, manifest, resumed)
+        # Together with the fresh no-candidate start, these are the five exact
+        # uploaded preparation prefixes authorized for unrestricted rerun.
+        self.assertEqual(
+            observed_uploaded_prefixes,
+            {"candidate-archive", "candidate-manifest", "backup", "receipt"},
+        )
+
+    def test_preexisting_starters_at_every_repair_step_conflict_without_deletion(self):
+        candidate_archive = (
+            "qlib_bin.repair-2026-07-20-"
+            + "0" * 40
+            + "-"
+            + "a" * 64
+            + "-"
+            + "b" * 64
+            + ".tar.gz"
+        )
+        candidate_manifest = candidate_archive[:-7] + ".manifest.json"
+
+        def asset(name, asset_id, state="uploaded", size=1):
+            return {"id": asset_id, "name": name, "state": state, "size": size}
+
+        original = asset("qlib_bin.tar.gz", 483488955)
+        ca = asset(candidate_archive, 2)
+        cm = asset(candidate_manifest, 3)
+        backup = asset("qlib_bin.original-2026-07-20-483488955.tar.gz", 4)
+        receipt = asset("qlib-repair-2026-07-20.json", 5)
+        fixtures = (
+            ([original, asset(candidate_archive, 20, "starter", 0)], True),
+            ([original, ca, asset(candidate_manifest, 21, "starter", 0)], True),
+            ([original, ca, cm, asset(backup["name"], 22, "starter", 0)], True),
+            ([original, ca, cm, backup, asset(receipt["name"], 23, "starter", 0)], True),
+            ([ca, cm, backup, receipt, asset("qlib_bin.tar.gz", 24, "starter", 0)], False),
+            ([ca, cm, backup, receipt, asset("qlib_bin.tar.gz", 6), asset("qlib_bin.manifest.json", 25, "starter", 0)], False),
+            ([original, asset(candidate_manifest, 26, "starter", 0)], True),
+            ([original, asset(candidate_archive, 27, "starter", 1)], True),
+            ([original, asset(candidate_archive, 28, "starter", 0), asset(candidate_archive, 29, "starter", 0)], True),
+            ([original, asset(candidate_archive, 30, "processing", 0)], True),
+        )
+        (self.root / "candidate-archive-name").write_text(candidate_archive)
+        (self.root / "candidate-manifest-name").write_text(candidate_manifest)
+        for index, (assets, original_present) in enumerate(fixtures):
+            with self.subTest(index=index):
+                fixture = self.root / f"preexisting-starter-{index}.json"
+                fixture.write_text(json.dumps(assets))
+                previous_source = self.source
+                self.source = fixture
+                try:
+                    body = r'''
+                      WORK_DIR=$1; SOURCE_FILE=$2; DELETE_LOG="$WORK_DIR/delete.log"
+                      CANDIDATE_ARCHIVE_NAME=$(cat "$WORK_DIR/candidate-archive-name")
+                      CANDIDATE_MANIFEST_NAME=$(cat "$WORK_DIR/candidate-manifest-name")
+                      github_delete_asset() { printf '%s\n' "$1" >>"$DELETE_LOG"; }
+                      if validate_repair_prefix "$(cat "$SOURCE_FILE")" ORIGINAL_PRESENT; then exit 1; fi
+                      [[ ! -e "$DELETE_LOG" ]]
+                    '''.replace("ORIGINAL_PRESENT", "true" if original_present else "false")
+                    result = self.run_bash(body)
+                finally:
+                    self.source = previous_source
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    def run_noisy_dolt_publish_case(
+        self, case_name, *, clone_required, fetch_status=0
+    ):
+        case_root = self.root / case_name
+        dolt_root = case_root / "dolt"
+        case_root.mkdir()
+        if not clone_required:
+            (dolt_root / "investment_data/.dolt").mkdir(parents=True)
+        body = r'''
+          CASE_ROOT=$1; FETCH_STATUS=$2
+          WORK_DIR="$CASE_ROOT/work"
+          DOLT_TEST_DIR="$CASE_ROOT/dolt"
+          mkdir -p "$WORK_DIR"
+          eval "$(declare -f select_normal_dolt_commit | sed \
+            's#local dolt_dir=/dolt checkout=/dolt/investment_data commit#local dolt_dir="$DOLT_TEST_DIR" checkout="$DOLT_TEST_DIR/investment_data" commit#')"
+          date() {
+            [[ "$*" == "+%F" ]] || return 90
+            printf '%s\n' '2026-07-20'
+          }
+          flock() { return 0; }
+          dolt() {
+            case "$1" in
+              clone)
+                printf '%s\n' 'noisy clone progress on stdout'
+                mkdir -p "$PWD/investment_data/.dolt"
+                ;;
+              status)
+                printf '%s\n' 'noisy status setup on stdout'
+                printf '%s\n' 'nothing to commit, working tree clean'
+                ;;
+              fetch)
+                [[ "$2" == --silent && "$3" == origin && "$4" == master ]] \
+                  || return 91
+                printf '%s\n' 'noisy fetch progress on stdout'
+                return "$FETCH_STATUS"
+                ;;
+              sql)
+                printf '%s\n' value '9vtplc2tar9ver7p6s1bus2oiedjvtqo'
+                ;;
+              *) return 92 ;;
+            esac
+          }
+          build_pair() {
+            local tag=$1 dolt_commit=$2 output_dir=$3
+            printf '%s\n' "$tag" "$dolt_commit" "$output_dir" \
+              >"$CASE_ROOT/build-args"
+            mkdir -p "$output_dir"
+            printf '%s\n' archive >"$output_dir/$ARCHIVE_NAME"
+            printf '%s\n' manifest >"$output_dir/$MANIFEST_NAME"
+          }
+          get_or_create_release() {
+            : >"$CASE_ROOT/release-accessed"
+            RELEASE_ID=42
+          }
+          list_assets() {
+            : >"$CASE_ROOT/assets-listed"
+            printf '%s\n' '[]'
+          }
+          ensure_uploaded_asset() {
+            cp "$2" "$4"
+            printf '%s\n' '{"id":1}'
+          }
+          redownload_named_asset() {
+            cp "$WORK_DIR/build/$1" "$2"
+            printf '%s\n' '{"id":1}'
+          }
+          validate_pair() {
+            [[ -f "$1" && -f "$2" && "$3" == 2026-07-20 ]]
+            : >"$CASE_ROOT/validated"
+          }
+          publish_current
+        '''
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$1"; shift; ' + body,
+                "bash",
+                str(ROOT / "upload_release.sh"),
+                str(case_root),
+                str(fetch_status),
+            ],
+            text=True,
+            capture_output=True,
+        )
+        return result, case_root
+
+    def assert_noisy_dolt_publish_succeeded(self, result, case_root):
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout,
+            "Validated release 2026-07-20 with immutable archive and manifest assets.\n",
+        )
+        self.assertNotIn("noisy", result.stdout)
+        self.assertIn("noisy fetch progress on stdout", result.stderr)
+        self.assertEqual(
+            (case_root / "build-args").read_text(encoding="utf-8").splitlines(),
+            [
+                "2026-07-20",
+                "9vtplc2tar9ver7p6s1bus2oiedjvtqo",
+                str(case_root / "work/build"),
+            ],
+        )
+        for name in ("release-accessed", "assets-listed", "validated"):
+            self.assertTrue((case_root / name).is_file(), name)
+
+    def test_publish_captures_exact_commit_when_dolt_fetch_is_noisy(self):
+        result, case_root = self.run_noisy_dolt_publish_case(
+            "noisy-fetch", clone_required=False
+        )
+        self.assert_noisy_dolt_publish_succeeded(result, case_root)
+        self.assertNotIn("noisy clone progress on stdout", result.stderr)
+
+    def test_publish_captures_exact_commit_when_initial_clone_is_noisy(self):
+        result, case_root = self.run_noisy_dolt_publish_case(
+            "noisy-clone", clone_required=True
+        )
+        self.assert_noisy_dolt_publish_succeeded(result, case_root)
+        self.assertIn("noisy clone progress on stdout", result.stderr)
+
+    def test_dolt_lock_contention_stops_before_build_delete_or_publication(self):
+        body = r'''
+          WORK_DIR=$1; SOURCE_FILE=$2
+          mkdir -p "$WORK_DIR/dolt/investment_data/.dolt"
+          eval "$(declare -f select_normal_dolt_commit | sed \
+            's#local dolt_dir=/dolt checkout=/dolt/investment_data commit#local dolt_dir="$WORK_DIR/dolt" checkout="$WORK_DIR/dolt/investment_data" commit#')"
+          flock() { return 1; }
+          dolt() {
+            case "$1" in
+              status) printf '%s\n' 'nothing to commit, working tree clean' ;;
+              fetch) return 0 ;;
+              sql) printf '%s\n' 'value' '9vtplc2tar9ver7p6s1bus2oiedjvtqo' ;;
+            esac
+          }
+          build_pair() { : >"$WORK_DIR/build"; }
+          github_delete_asset() { : >"$WORK_DIR/delete"; }
+          github_upload_asset() { : >"$WORK_DIR/publication"; }
+          if selected="$(select_normal_dolt_commit)"; then
+            build_pair
+            github_delete_asset
+            github_upload_asset
+          fi
+          [[ ! -e "$WORK_DIR/build" && ! -e "$WORK_DIR/delete" && ! -e "$WORK_DIR/publication" ]]
+        '''
+        result = self.run_bash(body)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_dirty_dolt_checkout_stops_before_build_delete_or_publication(self):
+        body = r'''
+          WORK_DIR=$1; SOURCE_FILE=$2
+          mkdir -p "$WORK_DIR/dolt/investment_data/.dolt"
+          eval "$(declare -f select_normal_dolt_commit | sed \
+            's#local dolt_dir=/dolt checkout=/dolt/investment_data commit#local dolt_dir="$WORK_DIR/dolt" checkout="$WORK_DIR/dolt/investment_data" commit#')"
+          flock() { return 0; }
+          dolt() {
+            case "$1" in
+              status) printf '%s\n' 'modified tables present' ;;
+              fetch) return 0 ;;
+              sql) printf '%s\n' 'value' '9vtplc2tar9ver7p6s1bus2oiedjvtqo' ;;
+            esac
+          }
+          build_pair() { : >"$WORK_DIR/build"; }
+          github_delete_asset() { : >"$WORK_DIR/delete"; }
+          github_upload_asset() { : >"$WORK_DIR/publication"; }
+          if selected="$(select_normal_dolt_commit)"; then
+            build_pair
+            github_delete_asset
+            github_upload_asset
+          fi
+          [[ ! -e "$WORK_DIR/build" && ! -e "$WORK_DIR/delete" && ! -e "$WORK_DIR/publication" ]]
+        '''
+        result = self.run_bash(body)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_publish_fetch_failure_stops_before_build_or_release_access(self):
+        result, case_root = self.run_noisy_dolt_publish_case(
+            "fetch-failure", clone_required=False, fetch_status=23
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("noisy fetch progress on stdout", result.stderr)
+        self.assertIn("failed to fetch shared Dolt origin/master", result.stderr)
+        for name in (
+            "build-args",
+            "release-accessed",
+            "assets-listed",
+            "validated",
+        ):
+            self.assertFalse((case_root / name).exists(), name)
+
+    def test_redownload_failure_stops_before_build_delete_or_publication(self):
+        body = r'''
+          WORK_DIR=$1; SOURCE_FILE=$2; RELEASE_ID=42
+          size="$(file_size "$SOURCE_FILE")"; digest="$(sha256_file "$SOURCE_FILE")"
+          list_assets() {
+            jq -cn --argjson size "$size" --arg digest "$digest" \
+              '[{id:91,name:"asset.bin",state:"uploaded",size:$size,digest:$digest}]'
+          }
+          github_download_asset() { return 17; }
+          build_pair() { : >"$WORK_DIR/build"; }
+          github_delete_asset() { : >"$WORK_DIR/delete"; }
+          github_upload_asset() { : >"$WORK_DIR/publication"; }
+          if asset="$(redownload_named_asset asset.bin "$WORK_DIR/downloaded")"; then
+            build_pair
+            github_delete_asset
+            github_upload_asset
+          fi
+          [[ ! -e "$WORK_DIR/build" && ! -e "$WORK_DIR/delete" && ! -e "$WORK_DIR/publication" ]]
+        '''
+        result = self.run_bash(body)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_starter_observed_before_this_invocation_is_never_deleted(self):
+        state = [
+            {
+                "id": 91,
+                "name": "asset.bin",
+                "state": "starter",
+                "size": 0,
+                "digest": None,
+            }
+        ]
+        (self.root / "state.json").write_text(json.dumps(state))
+        body = r'''
+          WORK_DIR=$1; SOURCE_FILE=$2; RELEASE_ID=42; ORIGIN_AUTHORITY_VERIFIED=true
+          STATE_FILE="$WORK_DIR/state.json"; DELETE_LOG="$WORK_DIR/delete.log"
+          list_assets() { cat "$STATE_FILE"; }
+          github_upload_asset() { printf upload >"$WORK_DIR/upload.log"; }
+          github_download_asset() { return 99; }
+          github_delete_asset() { printf '%s\n' "$1" >>"$DELETE_LOG"; }
+          github_get_asset_by_id_optional() { return 4; }
+          if ensure_uploaded_asset asset.bin "$SOURCE_FILE" application/octet-stream "$WORK_DIR/downloaded" \
+              >/dev/null 2>&1; then
+            exit 1
+          fi
+          [[ ! -e "$DELETE_LOG" && ! -e "$WORK_DIR/upload.log" ]]
+        '''
+        result = self.run_bash(body)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_starter_recovery_rejects_changed_release_authority(self):
+        state = [
+            {
+                "id": 91,
+                "name": "asset.bin",
+                "state": "starter",
+                "size": 0,
+                "digest": None,
+            }
+        ]
+        (self.root / "state.json").write_text(json.dumps(state))
+        body = r'''
+          WORK_DIR=$1; SOURCE_FILE=$2; RELEASE_ID=42; ORIGIN_AUTHORITY_VERIFIED=true
+          STATE_FILE="$WORK_DIR/state.json"; DELETE_LOG="$WORK_DIR/delete.log"
+          list_assets() { cat "$STATE_FILE"; }
+          github_delete_asset() { printf '%s\n' "$1" >>"$DELETE_LOG"; }
+          github_get_asset_by_id_optional() { return 4; }
+          if recover_exact_starter asset.bin 91 43 >/dev/null 2>&1; then exit 1; fi
+          [[ ! -e "$DELETE_LOG" ]]
+        '''
+        result = self.run_bash(body)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_duplicate_uploaded_plus_starter_conflicts_without_deletion(self):
+        digest = "sha256:" + hashlib.sha256(self.source.read_bytes()).hexdigest()
+        state = [
+            {"id": 1, "name": "asset.bin", "state": "uploaded", "size": self.source.stat().st_size, "digest": digest},
+            {"id": 2, "name": "asset.bin", "state": "starter", "size": 0, "digest": None},
+        ]
+        (self.root / "state.json").write_text(json.dumps(state))
+        body = r'''
+          WORK_DIR=$1; SOURCE_FILE=$2; RELEASE_ID=42; ORIGIN_AUTHORITY_VERIFIED=true
+          STATE_FILE="$WORK_DIR/state.json"; DELETE_LOG="$WORK_DIR/delete.log"
+          list_assets() { cat "$STATE_FILE"; }
+          github_upload_asset() { return 99; }
+          github_download_asset() { cp "$SOURCE_FILE" "$2"; }
+          github_delete_asset() { printf '%s\n' "$1" >>"$DELETE_LOG"; }
+          github_get_asset_by_id_optional() { return 4; }
+          if ensure_uploaded_asset asset.bin "$SOURCE_FILE" application/octet-stream "$WORK_DIR/downloaded" >/dev/null 2>&1; then
+            exit 1
+          fi
+          [[ ! -e "$DELETE_LOG" ]]
+        '''
+        result = self.run_bash(body)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_normal_and_fixed_releases_reject_draft_and_prerelease(self):
+        cases = (
+            {"draft": True, "prerelease": False},
+            {"draft": False, "prerelease": True},
+        )
+        for release_state in cases:
+            with self.subTest(kind="normal", **release_state):
+                release = {
+                    "id": 42,
+                    "tag_name": "2026-07-20",
+                    **release_state,
+                }
+                self.source.write_text(json.dumps(release))
+                body = r'''
+                  WORK_DIR=$1; SOURCE_FILE=$2
+                  github_get_release_by_tag_optional() { cat "$SOURCE_FILE"; }
+                  github_create_release() { printf create >"$WORK_DIR/mutation"; }
+                  if get_or_create_release 2026-07-20 >/dev/null 2>&1; then exit 1; fi
+                  [[ ! -e "$WORK_DIR/mutation" ]]
+                '''
+                result = self.run_bash(body)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+            with self.subTest(kind="fixed", **release_state):
+                release = {
+                    "id": 356733573,
+                    "tag_name": "2026-07-20",
+                    **release_state,
+                }
+                self.source.write_text(json.dumps(release))
+                body = r'''
+                  WORK_DIR=$1; SOURCE_FILE=$2
+                  github_api_get() { cat "$SOURCE_FILE"; }
+                  if verify_fixed_release >/dev/null 2>&1; then exit 1; fi
+                '''
+                result = self.run_bash(body)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_stateful_normal_publication_orders_uploads_and_validation(self):
+        pair_root = self.root / "pair"
+        pair_root.mkdir()
+        archive, manifest = build_pair(pair_root)
+        original = self.root / "unused-original"
+        original.write_bytes(b"unused")
+        (self.root / "state.json").write_text("[]\n")
+        (self.root / "next-id").write_text("100\n")
+
+        result = self.run_stateful_publisher("publish", archive, manifest, original)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        state = json.loads((self.root / "state.json").read_text())
+        self.assertEqual([asset["name"] for asset in state], ["qlib_bin.tar.gz", "qlib_bin.manifest.json"])
+        self.assertEqual(self.remote_bytes(state, "qlib_bin.tar.gz"), archive.read_bytes())
+        self.assertEqual(self.remote_bytes(state, "qlib_bin.manifest.json"), manifest.read_bytes())
+
+        events = (self.root / "events.log").read_text().splitlines()
+        archive_upload = next(index for index, value in enumerate(events) if value.startswith("upload:qlib_bin.tar.gz:"))
+        archive_download = next(index for index, value in enumerate(events) if value.startswith("download:qlib_bin.tar.gz:"))
+        manifest_upload = next(index for index, value in enumerate(events) if value.startswith("upload:qlib_bin.manifest.json:"))
+        final_validation = max(index for index, value in enumerate(events) if value.startswith("validate:"))
+        local_validation = next(index for index, value in enumerate(events) if value.startswith("validate:qlib_bin.tar.gz:"))
+        release_lookup = events.index("release:get-normal")
+        self.assertLess(local_validation, release_lookup)
+        self.assertLess(release_lookup, archive_upload)
+        self.assertLess(archive_upload, archive_download)
+        self.assertLess(archive_download, manifest_upload)
+        self.assertGreater(final_validation, manifest_upload)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            canonical_archive = Path(temporary) / "qlib_bin.tar.gz"
+            canonical_manifest = Path(temporary) / "qlib_bin.manifest.json"
+            canonical_archive.write_bytes(self.remote_bytes(state, "qlib_bin.tar.gz"))
+            canonical_manifest.write_bytes(self.remote_bytes(state, "qlib_bin.manifest.json"))
+            self.assertEqual(
+                run_validator(canonical_archive, canonical_manifest, "--require-publishable").returncode,
+                0,
+            )
+
+    def test_normal_publication_idempotence_archive_only_resume_and_conflicts(self):
+        pair_root = self.root / "normal-states-pair"
+        pair_root.mkdir()
+        archive, manifest = build_pair(pair_root)
+        original = self.root / "normal-unused-original"
+        original.write_bytes(b"unused")
+
+        self.reset_stateful_publish()
+        first = self.run_stateful_publisher("publish", archive, manifest, original)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        events_before = (self.root / "events.log").read_text().splitlines()
+        second = self.run_stateful_publisher("publish", archive, manifest, original)
+        self.assertEqual(second.returncode, 0, second.stderr)
+        events_after = (self.root / "events.log").read_text().splitlines()
+        self.assertEqual(
+            [event for event in events_before if event.startswith(("upload:", "delete:"))],
+            [event for event in events_after if event.startswith(("upload:", "delete:"))],
+        )
+
+        state = json.loads((self.root / "state.json").read_text())
+        manifest_asset = next(
+            item for item in state if item["name"] == "qlib_bin.manifest.json"
+        )
+        state = [item for item in state if item["id"] != manifest_asset["id"]]
+        (self.root / "state.json").write_text(json.dumps(state) + "\n")
+        (self.root / "remote" / str(manifest_asset["id"])).unlink()
+        resumed = self.run_stateful_publisher("publish", archive, manifest, original)
+        self.assertEqual(resumed.returncode, 0, resumed.stderr)
+        new_events = (self.root / "events.log").read_text().splitlines()[len(events_after) :]
+        self.assertEqual(
+            [event.split(":", 2)[1] for event in new_events if event.startswith("upload:")],
+            ["qlib_bin.manifest.json"],
+        )
+
+        for conflict in ("manifest-only", "different-archive", "duplicate-archive", "starter"):
+            with self.subTest(conflict=conflict):
+                self.reset_stateful_publish()
+                remote = self.root / "remote"
+                remote.mkdir(exist_ok=True)
+                if conflict == "manifest-only":
+                    files = [(101, "qlib_bin.manifest.json", manifest, "uploaded", manifest.stat().st_size)]
+                elif conflict == "different-archive":
+                    other = self.root / "different-archive"
+                    other.write_bytes(b"different")
+                    files = [(101, "qlib_bin.tar.gz", other, "uploaded", other.stat().st_size)]
+                elif conflict == "duplicate-archive":
+                    files = [
+                        (101, "qlib_bin.tar.gz", archive, "uploaded", archive.stat().st_size),
+                        (102, "qlib_bin.tar.gz", archive, "uploaded", archive.stat().st_size),
+                    ]
+                else:
+                    files = [(101, "qlib_bin.tar.gz", None, "starter", 0)]
+                assets = []
+                for asset_id, name, path, state_name, size in files:
+                    digest = None
+                    if path is not None:
+                        shutil.copy2(path, remote / str(asset_id))
+                        digest = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+                    assets.append(
+                        {
+                            "id": asset_id,
+                            "name": name,
+                            "state": state_name,
+                            "size": size,
+                            "digest": digest,
+                            "created_at": "2026-07-21T12:00:00Z",
+                            "updated_at": "2026-07-21T12:00:01Z",
+                        }
+                    )
+                (self.root / "state.json").write_text(json.dumps(assets) + "\n")
+                result = self.run_stateful_publisher(
+                    "publish", archive, manifest, original
+                )
+                self.assertNotEqual(result.returncode, 0)
+                events = (
+                    (self.root / "events.log").read_text().splitlines()
+                    if (self.root / "events.log").exists()
+                    else []
+                )
+                self.assertFalse(
+                    any(event.startswith(("upload:", "delete:")) for event in events),
+                    events,
+                )
+
+    def test_normal_upload_lost_responses_refetch_exact_uploaded_bytes(self):
+        pair_root = self.root / "normal-lost-pair"
+        pair_root.mkdir()
+        archive, manifest = build_pair(pair_root)
+        original = self.root / "normal-lost-unused"
+        original.write_bytes(b"unused")
+        for name in ("qlib_bin.tar.gz", "qlib_bin.manifest.json"):
+            with self.subTest(name=name):
+                self.reset_stateful_publish()
+                result = self.run_stateful_publisher(
+                    "publish", archive, manifest, original, name, "lost"
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                state = json.loads((self.root / "state.json").read_text())
+                self.assertEqual(
+                    [asset["name"] for asset in state],
+                    ["qlib_bin.tar.gz", "qlib_bin.manifest.json"],
+                )
+
+    def test_stateful_fixed_repair_resumes_after_exact_original_deletion(self):
+        pair_root = self.root / "pair"
+        pair_root.mkdir()
+        archive, manifest = build_pair(pair_root)
+        original = self.root / "original.tar.gz"
+        original.write_bytes(b"captured original archive bytes")
+        original_digest = "sha256:" + hashlib.sha256(original.read_bytes()).hexdigest()
+        original_asset = {
+            "id": 483488955,
+            "name": "qlib_bin.tar.gz",
+            "state": "uploaded",
+            "size": original.stat().st_size,
+            "digest": original_digest,
+            "created_at": "2026-07-20T13:26:30Z",
+            "updated_at": "2026-07-20T13:26:48Z",
+        }
+        (self.root / "state.json").write_text(json.dumps([original_asset]) + "\n")
+        (self.root / "next-id").write_text("500000001\n")
+        remote = self.root / "remote"
+        remote.mkdir()
+        shutil.copy2(original, remote / "483488955")
+
+        interrupted = self.run_stateful_publisher(
+            "repair", archive, manifest, original, "original-delete", "after"
+        )
+        self.assertNotEqual(interrupted.returncode, 0)
+        post_delete = json.loads((self.root / "state.json").read_text())
+        post_delete_names = [asset["name"] for asset in post_delete]
+        self.assertNotIn("qlib_bin.tar.gz", post_delete_names)
+        self.assertNotIn("qlib_bin.manifest.json", post_delete_names)
+        self.assertIn("qlib_bin.original-2026-07-20-483488955.tar.gz", post_delete_names)
+        self.assertIn("qlib-repair-2026-07-20.json", post_delete_names)
+
+        resumed = self.run_stateful_publisher("repair", archive, manifest, original)
+        self.assertEqual(resumed.returncode, 0, resumed.stderr)
+        state = json.loads((self.root / "state.json").read_text())
+        names = [asset["name"] for asset in state]
+        candidate_archive = next(name for name in names if name.startswith("qlib_bin.repair-") and name.endswith(".tar.gz"))
+        candidate_manifest = next(name for name in names if name.startswith("qlib_bin.repair-") and name.endswith(".manifest.json"))
+        self.assertEqual(
+            names,
+            [
+                candidate_archive,
+                candidate_manifest,
+                "qlib_bin.original-2026-07-20-483488955.tar.gz",
+                "qlib-repair-2026-07-20.json",
+                "qlib_bin.tar.gz",
+                "qlib_bin.manifest.json",
+            ],
+        )
+        self.assertEqual(self.remote_bytes(state, "qlib_bin.tar.gz"), archive.read_bytes())
+        self.assertEqual(self.remote_bytes(state, "qlib_bin.manifest.json"), manifest.read_bytes())
+        self.assertEqual(self.remote_bytes(state, candidate_archive), archive.read_bytes())
+        self.assertEqual(self.remote_bytes(state, candidate_manifest), manifest.read_bytes())
+        self.assertEqual(
+            self.remote_bytes(state, "qlib_bin.original-2026-07-20-483488955.tar.gz"),
+            original.read_bytes(),
+        )
+
+        events = (self.root / "events.log").read_text().splitlines()
+        uploads = [value.split(":", 2)[1] for value in events if value.startswith("upload:")]
+        self.assertEqual(
+            uploads,
+            [
+                candidate_archive,
+                candidate_manifest,
+                "qlib_bin.original-2026-07-20-483488955.tar.gz",
+                "qlib-repair-2026-07-20.json",
+                "qlib_bin.tar.gz",
+                "qlib_bin.manifest.json",
+            ],
+        )
+        deletions = [value for value in events if value.startswith("delete:")]
+        self.assertEqual(deletions, ["delete:qlib_bin.tar.gz:483488955"])
+        delete_index = events.index(deletions[0])
+        for required_download in (
+            candidate_archive,
+            candidate_manifest,
+            "qlib_bin.original-2026-07-20-483488955.tar.gz",
+            "qlib-repair-2026-07-20.json",
+        ):
+            self.assertTrue(
+                any(
+                    index < delete_index and value.startswith(f"download:{required_download}:")
+                    for index, value in enumerate(events)
+                ),
+                required_download,
+            )
+        self.assertTrue(any(index < delete_index and value.startswith("validate:") for index, value in enumerate(events)))
+        canonical_manifest_upload = max(
+            index for index, value in enumerate(events) if value.startswith("upload:qlib_bin.manifest.json:")
+        )
+        self.assertTrue(any(index > canonical_manifest_upload and value.startswith("validate:") for index, value in enumerate(events)))
+
+        with tempfile.TemporaryDirectory() as temporary:
+            canonical_archive = Path(temporary) / "qlib_bin.tar.gz"
+            canonical_manifest = Path(temporary) / "qlib_bin.manifest.json"
+            canonical_archive.write_bytes(self.remote_bytes(state, "qlib_bin.tar.gz"))
+            canonical_manifest.write_bytes(self.remote_bytes(state, "qlib_bin.manifest.json"))
+            self.assertEqual(
+                run_validator(canonical_archive, canonical_manifest, "--require-publishable").returncode,
+                0,
+            )
+
+    def test_receipt_has_exact_nested_manifest_and_asset_record_shapes(self):
+        archive, manifest = build_pair(self.root)
+        candidate_manifest = self.root / "candidate.manifest.json"
+        shutil.copy2(manifest, candidate_manifest)
+        candidate_archive = self.root / "candidate.tar.gz"
+        shutil.copy2(archive, candidate_archive)
+        asset_template = {
+            "id": 500000001,
+            "name": "placeholder",
+            "state": "uploaded",
+            "size": archive.stat().st_size,
+            "digest": "sha256:" + hashlib.sha256(archive.read_bytes()).hexdigest(),
+            "created_at": "2026-07-21T12:00:00Z",
+            "updated_at": "2026-07-21T12:00:01Z",
+        }
+        backup = dict(asset_template, name="qlib_bin.original-2026-07-20-483488955.tar.gz")
+        candidate_archive_json = dict(asset_template, id=500000002, name="candidate.tar.gz")
+        candidate_manifest_json = dict(
+            asset_template,
+            id=500000003,
+            name="candidate.manifest.json",
+            size=candidate_manifest.stat().st_size,
+            digest="sha256:" + hashlib.sha256(candidate_manifest.read_bytes()).hexdigest(),
+        )
+        receipt = self.root / "receipt.json"
+        body = r'''
+          WORK_DIR=$1; SOURCE_FILE=$2
+          CANDIDATE_ARCHIVE_LOCAL="$WORK_DIR/candidate.tar.gz"
+          CANDIDATE_MANIFEST_LOCAL="$WORK_DIR/candidate.manifest.json"
+          create_receipt "$WORK_DIR/qlib_bin.manifest.json" "$WORK_DIR/receipt.json" \
+            "$(cat "$WORK_DIR/backup.json")" "$(cat "$WORK_DIR/candidate-archive.json")" \
+            "$(cat "$WORK_DIR/candidate-manifest.json")"
+        '''
+        (self.root / "backup.json").write_text(json.dumps(backup))
+        (self.root / "candidate-archive.json").write_text(json.dumps(candidate_archive_json))
+        (self.root / "candidate-manifest.json").write_text(json.dumps(candidate_manifest_json))
+        result = self.run_bash(body)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        document = json.loads(receipt.read_text())
+        self.assertEqual(list(document), ["operation", "release_tag", "release_id", "authority", "manifest", "assets"])
+        self.assertEqual(list(document["manifest"]), list(manifest_payload(archive)))
+        self.assertEqual(
+            list(document["assets"]),
+            ["original", "backup", "candidate_archive", "candidate_manifest", "canonical_archive", "canonical_manifest"],
+        )
+        record_keys = ["asset_id", "name", "state", "size_bytes", "sha256", "created_at", "updated_at"]
+        for record in document["assets"].values():
+            self.assertEqual(list(record), record_keys)
+
+    def test_six_record_receipt_validator_enforces_types_rfc3339_nulls_and_live_fields(self):
+        archive, manifest = build_pair(self.root)
+        original = self.root / "receipt-original.tar.gz"
+        backup_file = self.root / "receipt-backup.tar.gz"
+        original.write_bytes(b"captured original")
+        shutil.copy2(original, backup_file)
+        candidate_archive = self.root / "receipt-candidate.tar.gz"
+        candidate_manifest = self.root / "receipt-candidate.manifest.json"
+        shutil.copy2(archive, candidate_archive)
+        shutil.copy2(manifest, candidate_manifest)
+        candidate_archive_name = (
+            "qlib_bin.repair-2026-07-20-"
+            + "0" * 40
+            + "-"
+            + "a" * 64
+            + "-"
+            + hashlib.sha256(archive.read_bytes()).hexdigest()
+            + ".tar.gz"
+        )
+        candidate_manifest_name = candidate_archive_name[:-7] + ".manifest.json"
+
+        def api_asset(asset_id, name, path):
+            return {
+                "id": asset_id,
+                "name": name,
+                "state": "uploaded",
+                "size": path.stat().st_size,
+                "digest": "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest(),
+                "created_at": "2026-07-21T12:00:00Z",
+                "updated_at": "2026-07-21T12:00:01Z",
+            }
+
+        live = {
+            "original": api_asset(483488955, "qlib_bin.tar.gz", original),
+            "backup": api_asset(
+                500000001,
+                "qlib_bin.original-2026-07-20-483488955.tar.gz",
+                backup_file,
+            ),
+            "candidate_archive": api_asset(
+                500000002, candidate_archive_name, candidate_archive
+            ),
+            "candidate_manifest": api_asset(
+                500000003, candidate_manifest_name, candidate_manifest
+            ),
+        }
+        live["original"]["created_at"] = "2026-07-20T13:26:30Z"
+        live["original"]["updated_at"] = "2026-07-20T13:26:48Z"
+        for name, payload in live.items():
+            (self.root / f"live-{name}.json").write_text(json.dumps(payload))
+        receipt = self.root / "validated-receipt.json"
+        create_body = r'''
+          WORK_DIR=$1; SOURCE_FILE=$2
+          CANDIDATE_ARCHIVE_NAME=$(cat "$WORK_DIR/candidate-archive-name")
+          CANDIDATE_MANIFEST_NAME=$(cat "$WORK_DIR/candidate-manifest-name")
+          CANDIDATE_ARCHIVE_LOCAL="$WORK_DIR/receipt-candidate.tar.gz"
+          CANDIDATE_MANIFEST_LOCAL="$WORK_DIR/receipt-candidate.manifest.json"
+          FIXED_ORIGINAL_SIZE=$(file_size "$WORK_DIR/receipt-original.tar.gz")
+          FIXED_ORIGINAL_DIGEST=$(sha256_file "$WORK_DIR/receipt-original.tar.gz")
+          create_receipt "$WORK_DIR/qlib_bin.manifest.json" "$WORK_DIR/validated-receipt.json" \
+            "$(cat "$WORK_DIR/live-backup.json")" \
+            "$(cat "$WORK_DIR/live-candidate_archive.json")" \
+            "$(cat "$WORK_DIR/live-candidate_manifest.json")"
+          validate_repair_receipt pre-delete \
+            "$WORK_DIR/validated-receipt.json" "$WORK_DIR/qlib_bin.manifest.json" \
+            "$(cat "$WORK_DIR/live-original.json")" \
+            "$(cat "$WORK_DIR/live-backup.json")" \
+            "$(cat "$WORK_DIR/live-candidate_archive.json")" \
+            "$(cat "$WORK_DIR/live-candidate_manifest.json")" \
+            null null "$WORK_DIR/receipt-backup.tar.gz" \
+            "$WORK_DIR/receipt-candidate.tar.gz" \
+            "$WORK_DIR/receipt-candidate.manifest.json" - -
+        '''
+        (self.root / "candidate-archive-name").write_text(candidate_archive_name)
+        (self.root / "candidate-manifest-name").write_text(candidate_manifest_name)
+        result = self.run_bash(create_body)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        base = json.loads(receipt.read_text())
+        self.assertEqual(
+            list(base["assets"]),
+            [
+                "original",
+                "backup",
+                "candidate_archive",
+                "candidate_manifest",
+                "canonical_archive",
+                "canonical_manifest",
+            ],
+        )
+
+        validate_body = create_body[create_body.index("          validate_repair_receipt") :]
+        mutations = {}
+        value = json.loads(json.dumps(base))
+        value["assets"].pop("original")
+        mutations["missing-record"] = value
+        value = json.loads(json.dumps(base))
+        value["assets"]["backup"]["asset_id"] = True
+        mutations["boolean-id"] = value
+        value = json.loads(json.dumps(base))
+        value["assets"]["backup"]["created_at"] = "2026-07-21 12:00:00"
+        mutations["bad-rfc3339"] = value
+        value = json.loads(json.dumps(base))
+        value["assets"]["backup"]["updated_at"] = None
+        mutations["illegal-null"] = value
+        value = json.loads(json.dumps(base))
+        value["assets"]["canonical_archive"]["asset_id"] = 9
+        mutations["planned-id-not-null"] = value
+        value = json.loads(json.dumps(base))
+        value["assets"]["candidate_archive"]["sha256"] = "sha256:" + "A" * 64
+        mutations["noncanonical-hash"] = value
+        value = json.loads(json.dumps(base))
+        value["authority"]["image_digest"] = "sha256:" + "b" * 64
+        mutations["authority-mismatch"] = value
+        for label, document in mutations.items():
+            with self.subTest(label=label):
+                receipt.write_text(
+                    json.dumps(document, separators=(",", ":")) + "\n"
+                )
+                result = self.run_bash(validate_body)
+                self.assertNotEqual(result.returncode, 0)
+
+        receipt.write_text(json.dumps(base, separators=(",", ":")) + "\n")
+        changed_live = dict(live["backup"], updated_at="2026-07-21T12:00:02Z")
+        (self.root / "live-backup.json").write_text(json.dumps(changed_live))
+        result = self.run_bash(validate_body)
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_metadata_bytes_receipt_and_manifest_tampering_never_reaches_original_delete(self):
+        pair_root = self.root / "tamper-pair"
+        pair_root.mkdir()
+        archive, manifest = build_pair(pair_root)
+        original = self.root / "tamper-original.tar.gz"
+        original.write_bytes(b"captured original archive bytes")
+        names = self.repair_boundary_names(archive)
+        for tamper in ("metadata", "bytes", "receipt", "manifest"):
+            with self.subTest(tamper=tamper):
+                self.reset_stateful_repair(original)
+                prepared = self.run_stateful_publisher(
+                    "repair",
+                    archive,
+                    manifest,
+                    original,
+                    names["receipt"],
+                    "after",
+                )
+                self.assertNotEqual(prepared.returncode, 0)
+                state_path = self.root / "state.json"
+                state = json.loads(state_path.read_text())
+
+                if tamper == "metadata":
+                    asset = next(
+                        item
+                        for item in state
+                        if item["name"] == names["candidate-archive"]
+                    )
+                    asset["updated_at"] = "2026-07-21T12:00:09Z"
+                else:
+                    target_name = {
+                        "bytes": names["backup"],
+                        "receipt": names["receipt"],
+                        "manifest": names["candidate-manifest"],
+                    }[tamper]
+                    asset = next(item for item in state if item["name"] == target_name)
+                    remote_path = self.root / "remote" / str(asset["id"])
+                    if tamper == "receipt":
+                        document = json.loads(remote_path.read_text())
+                        document["assets"]["backup"]["updated_at"] = (
+                            "2026-07-21T12:00:09Z"
+                        )
+                        remote_path.write_text(
+                            json.dumps(document, separators=(",", ":")) + "\n"
+                        )
+                    else:
+                        remote_path.write_bytes(remote_path.read_bytes() + b"tamper")
+                    asset["size"] = remote_path.stat().st_size
+                    asset["digest"] = (
+                        "sha256:" + hashlib.sha256(remote_path.read_bytes()).hexdigest()
+                    )
+                state_path.write_text(json.dumps(state) + "\n")
+                rerun = self.run_stateful_publisher(
+                    "repair", archive, manifest, original
+                )
+                self.assertNotEqual(rerun.returncode, 0)
+                events = (self.root / "events.log").read_text().splitlines()
+                self.assertNotIn("delete:qlib_bin.tar.gz:483488955", events)
+
+    def test_only_uploaded_asset_repair_prefixes_are_recognized_on_rerun(self):
+        candidate_archive = "qlib_bin.repair-2026-07-20-" + "0" * 40 + "-" + "a" * 64 + "-" + "b" * 64 + ".tar.gz"
+        candidate_manifest = candidate_archive[:-7] + ".manifest.json"
+
+        def asset(name, state="uploaded", asset_id=1):
+            return {"id": asset_id, "name": name, "state": state, "size": 0 if state == "starter" else 1}
+
+        original = asset("qlib_bin.tar.gz", asset_id=483488955)
+        ca_up = asset(candidate_archive, asset_id=2)
+        cm_up = asset(candidate_manifest, asset_id=3)
+        backup_up = asset("qlib_bin.original-2026-07-20-483488955.tar.gz", asset_id=4)
+        receipt_up = asset("qlib-repair-2026-07-20.json", asset_id=5)
+        valid = [
+            ([original], True),
+            ([original, ca_up], True),
+            ([original, ca_up, cm_up], True),
+            ([original, ca_up, cm_up, backup_up], True),
+            ([original, ca_up, cm_up, backup_up, receipt_up], True),
+            ([ca_up, cm_up, backup_up, receipt_up], False),
+            ([ca_up, cm_up, backup_up, receipt_up, asset("qlib_bin.tar.gz", "uploaded", 6)], False),
+            ([ca_up, cm_up, backup_up, receipt_up, asset("qlib_bin.tar.gz", "uploaded", 6), asset("qlib_bin.manifest.json", "uploaded", 7)], False),
+        ]
+        for index, (assets, original_present) in enumerate(valid):
+            fixture = self.root / f"prefix-{index}.json"
+            fixture.write_text(json.dumps(assets))
+            body = r'''
+              WORK_DIR=$1; SOURCE_FILE=$2
+              CANDIDATE_ARCHIVE_NAME=$(cat "$WORK_DIR/candidate-archive-name")
+              CANDIDATE_MANIFEST_NAME=$(cat "$WORK_DIR/candidate-manifest-name")
+              validate_repair_prefix "$(cat "$SOURCE_FILE")" ORIGINAL_PRESENT
+            '''.replace("ORIGINAL_PRESENT", "true" if original_present else "false")
+            (self.root / "candidate-archive-name").write_text(candidate_archive)
+            (self.root / "candidate-manifest-name").write_text(candidate_manifest)
+            previous_source = self.source
+            self.source = fixture
+            try:
+                result = self.run_bash(body)
+            finally:
+                self.source = previous_source
+            self.assertEqual(result.returncode, 0, f"prefix {index}: {result.stderr}")
+
+    def test_externally_created_repair_states_conflict(self):
+        candidate_archive = "qlib_bin.repair-2026-07-20-" + "0" * 40 + "-" + "a" * 64 + "-" + "b" * 64 + ".tar.gz"
+        candidate_manifest = candidate_archive[:-7] + ".manifest.json"
+
+        def uploaded(name, asset_id):
+            return {"id": asset_id, "name": name, "state": "uploaded", "size": 1}
+
+        original = uploaded("qlib_bin.tar.gz", 483488955)
+        conflicts = [
+            ([original, uploaded(candidate_manifest, 3)], True),
+            ([original, uploaded("qlib_bin.original-2026-07-20-483488955.tar.gz", 4)], True),
+            ([original, uploaded("qlib-repair-2026-07-20.json", 5)], True),
+            ([uploaded(candidate_archive, 2)], False),
+            ([uploaded(candidate_archive + ".external", 9)], True),
+            ([original, uploaded(candidate_archive, 2), uploaded(candidate_archive, 8)], True),
+        ]
+        (self.root / "candidate-archive-name").write_text(candidate_archive)
+        (self.root / "candidate-manifest-name").write_text(candidate_manifest)
+        for index, (assets, original_present) in enumerate(conflicts):
+            fixture = self.root / f"conflict-{index}.json"
+            fixture.write_text(json.dumps(assets))
+            body = r'''
+              WORK_DIR=$1; SOURCE_FILE=$2
+              CANDIDATE_ARCHIVE_NAME=$(cat "$WORK_DIR/candidate-archive-name")
+              CANDIDATE_MANIFEST_NAME=$(cat "$WORK_DIR/candidate-manifest-name")
+              validate_repair_prefix "$(cat "$SOURCE_FILE")" ORIGINAL_PRESENT
+            '''.replace("ORIGINAL_PRESENT", "true" if original_present else "false")
+            previous_source = self.source
+            self.source = fixture
+            try:
+                result = self.run_bash(body)
+            finally:
+                self.source = previous_source
+            self.assertNotEqual(result.returncode, 0, f"conflict {index} was accepted")
+
+
+class CollectorFixtureTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.home = self.root / "home"
+        self.bin = self.home / ".local/bin"
+        self.bin.mkdir(parents=True)
+        self.today = "2026-07-20"
+        self.archive, self.manifest = build_pair(self.root)
+        payload = json.loads(self.manifest.read_text())
+        payload["release_tag"] = self.today
+        write_manifest(self.manifest, payload)
+        self.deployed_scripts = self.root / "deployed/scripts"
+        self.deployed_scripts.mkdir(parents=True)
+        shutil.copy2(
+            ROOT / "ops/investment-data-project-monitor/collect_health.sh",
+            self.deployed_scripts / "collect_health.sh",
+        )
+        shutil.copy2(VALIDATOR, self.deployed_scripts / "validate_archive.py")
+        self._write_stubs()
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def _write_executable(self, name, text):
+        path = self.bin / name
+        path.write_text(text)
+        os.chmod(path, 0o755)
+
+    def _write_release(self, assets):
+        release = {
+            "tagName": self.today,
+            "isDraft": False,
+            "isPrerelease": False,
+            "publishedAt": self.today + "T12:00:00Z",
+            "url": "https://example.invalid/release",
+            "assets": assets,
+        }
+        (self.root / "release.json").write_text(json.dumps(release))
+
+    def _asset_view(self, name, api_url, size, state="uploaded"):
+        return {"apiUrl": api_url, "id": "node", "name": name, "size": size, "state": state, "url": "https://example.invalid"}
+
+    def _write_stubs(self):
+        archive_url = "https://api.github.invalid/archive"
+        manifest_url = "https://api.github.invalid/manifest"
+        archive_digest = "sha256:" + hashlib.sha256(self.archive.read_bytes()).hexdigest()
+        manifest_digest = "sha256:" + hashlib.sha256(self.manifest.read_bytes()).hexdigest()
+        (self.root / "archive-identity.json").write_text(
+            json.dumps({"url": archive_url, "name": "qlib_bin.tar.gz", "state": "uploaded", "size": self.archive.stat().st_size, "digest": archive_digest})
+        )
+        (self.root / "manifest-identity.json").write_text(
+            json.dumps({"url": manifest_url, "name": "qlib_bin.manifest.json", "state": "uploaded", "size": self.manifest.stat().st_size, "digest": manifest_digest})
+        )
+        self._write_release(
+            [
+                self._asset_view("qlib_bin.tar.gz", archive_url, self.archive.stat().st_size),
+                self._asset_view("qlib_bin.manifest.json", manifest_url, self.manifest.stat().st_size),
+            ]
+        )
+        self._write_executable(
+            "date",
+            """#!/usr/bin/env bash
+case "$*" in
+  +%F) printf '%s\n' '2026-07-20' ;;
+  '+%Y-%m-%d %H:%M:%S %Z %z') printf '%s\n' '2026-07-20 21:30:00 CST +0800' ;;
+  +%H%M) printf '%s\n' '2130' ;;
+  '-u +%s') printf '%s\n' '1784554200' ;;
+  *) /usr/bin/date "$@" ;;
+esac
+""",
+        )
+        self._write_executable(
+            "curl",
+            """#!/usr/bin/env bash
+if [[ "$*" == *final_a_stock_eod_price* ]]; then
+  printf '%s\n' '{"rows":[{"max_date":"2026-07-20"}]}'
+else
+  printf '%s\n' '{"rows":[{"expected_date":"2026-07-20"}]}'
+fi
+""",
+        )
+        self._write_executable(
+            "minikube",
+            """#!/usr/bin/env bash
+case "$*" in
+  *"status"*) printf '%s\n' '{"Host":"Running"}' ;;
+  *"get nodes"*) printf '%s\n' '{"items":[{"metadata":{"name":"node"},"status":{"conditions":[{"type":"Ready","status":"True"}],"nodeInfo":{"kernelVersion":"x","containerRuntimeVersion":"x"}}}]}' ;;
+  *"get pods"*) printf '%s\n' '{"items":[{"metadata":{"namespace":"arc-systems","name":"controller"},"status":{"phase":"Running","containerStatuses":[{"ready":true,"restartCount":0}],"startTime":"2026-07-20T00:00:00Z"}},{"metadata":{"namespace":"arc-systems","name":"listener"},"status":{"phase":"Running","containerStatuses":[{"ready":true,"restartCount":0}],"startTime":"2026-07-20T00:00:00Z"}}]}' ;;
+  *"autoscalingrunnerset"*) printf '%s\n' '{"metadata":{"name":"investment-arc"},"spec":{"minRunners":0,"maxRunners":1},"status":{}}' ;;
+  *"get pvc"*) printf '%s\n' '{"metadata":{"name":"investment-data-docker-graph"},"status":{"phase":"Bound","capacity":{"storage":"100Gi"}},"spec":{"storageClassName":"standard"}}' ;;
+esac
+""",
+        )
+        self._write_executable(
+            "df",
+            """#!/usr/bin/env bash
+printf '%s\n' 'Filesystem 1024-blocks Used Available Capacity Mounted on'
+printf '/dev/test 100 1 99 %s%% %s\n' "${FIXTURE_DISK_PERCENT:-89}" "${@: -1}"
+""",
+        )
+        self._write_executable(
+            "gh",
+            """#!/usr/bin/env bash
+if [[ "$1 $2" == "run list" ]]; then
+  printf '%s\n' '[{"databaseId":1,"status":"completed","conclusion":"success","createdAt":"2026-07-20T00:00:00Z","updatedAt":"2026-07-20T00:01:00Z","url":"https://example.invalid/run","headBranch":"main","event":"schedule"}]'
+elif [[ "$1 $2" == "release view" ]]; then
+  cat "$FIXTURE_ROOT/release.json"
+elif [[ "$1" == api ]]; then
+  url="${@: -1}"
+  if [[ "$*" == *"application/octet-stream"* ]]; then
+    printf '%s\n' "$url" >>"$FIXTURE_ROOT/downloads.log"
+    if [[ "$url" == *archive ]]; then cat "$FIXTURE_ARCHIVE"; else cat "$FIXTURE_MANIFEST"; fi
+  elif [[ "$url" == *archive ]]; then
+    cat "$FIXTURE_ROOT/archive-identity.json"
+  else
+    cat "$FIXTURE_ROOT/manifest-identity.json"
+  fi
+else
+  exit 1
+fi
+""",
+        )
+
+    def run_collector(self, disk_percent=89):
+        env = {
+            **os.environ,
+            "HOME": str(self.home),
+            "FIXTURE_ROOT": str(self.root),
+            "FIXTURE_ARCHIVE": str(self.archive),
+            "FIXTURE_MANIFEST": str(self.manifest),
+            "FIXTURE_DISK_PERCENT": str(disk_percent),
+        }
+        return subprocess.run(
+            ["bash", str(self.deployed_scripts / "collect_health.sh")],
+            text=True,
+            capture_output=True,
+            env=env,
+        )
+
+    def test_valid_pair_is_downloaded_and_validator_document_is_preserved(self):
+        result = self.run_collector()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertTrue(report["release"]["valid"])
+        self.assertTrue(report["release"]["archive_validation"]["ok"])
+        self.assertEqual(report["overall_status"], "healthy")
+        second = self.run_collector()
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertEqual(
+            len((self.root / "downloads.log").read_text().splitlines()), 4
+        )
+
+    def test_host_disk_boundary_is_healthy_at_89_and_degraded_at_90(self):
+        healthy = self.run_collector(disk_percent=89)
+        self.assertEqual(healthy.returncode, 0, healthy.stderr)
+        healthy_report = json.loads(healthy.stdout)
+        self.assertEqual(healthy_report["platform"]["host_disk_used_percent"], 89)
+        self.assertEqual(healthy_report["overall_status"], "healthy")
+
+        degraded = self.run_collector(disk_percent=90)
+        self.assertEqual(degraded.returncode, 0, degraded.stderr)
+        degraded_report = json.loads(degraded.stdout)
+        self.assertEqual(degraded_report["platform"]["host_disk_used_percent"], 90)
+        self.assertEqual(degraded_report["overall_status"], "degraded")
+
+    def test_duplicate_name_is_invalid_without_validator_invocation(self):
+        release = json.loads((self.root / "release.json").read_text())
+        duplicate = dict(release["assets"][0], id="starter", state="starter", size=0)
+        release["assets"].append(duplicate)
+        (self.root / "release.json").write_text(json.dumps(release))
+        result = self.run_collector()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertFalse(report["release"]["valid"])
+        self.assertIsNone(report["release"]["archive_validation"])
+        self.assertEqual(report["overall_status"], "degraded")
+
+    def test_draft_and_prerelease_release_states_are_rejected(self):
+        for field in ("isDraft", "isPrerelease"):
+            with self.subTest(field=field):
+                release = json.loads((self.root / "release.json").read_text())
+                release[field] = True
+                (self.root / "release.json").write_text(json.dumps(release))
+                result = self.run_collector()
+                self.assertEqual(result.returncode, 0, result.stderr)
+                report = json.loads(result.stdout)
+                self.assertFalse(report["release"]["valid"])
+                self.assertIsNone(report["release"]["archive_validation"])
+                release[field] = False
+                (self.root / "release.json").write_text(json.dumps(release))
+
+    def test_validator_semantic_failure_is_unmodified_and_invalid(self):
+        members = dict(REQUIRED)
+        members["qlib_bin/instruments/csi300.txt"] = "sh600000\t2026-07-17\t2026-07-17\n"
+        self.archive = build_archive(self.archive, members)
+        payload = json.loads(self.manifest.read_text())
+        payload["archive_size_bytes"] = self.archive.stat().st_size
+        payload["archive_sha256"] = "sha256:" + hashlib.sha256(self.archive.read_bytes()).hexdigest()
+        write_manifest(self.manifest, payload)
+        self._write_stubs()
+        result = self.run_collector()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertFalse(report["release"]["valid"])
+        self.assertEqual(report["release"]["archive_validation"], {"ok": False, "error": "target-mismatch"})
+        self.assertEqual(report["overall_status"], "degraded")
+
+    def test_api_metadata_and_download_tampering_block_semantic_acceptance(self):
+        cases = ("api-digest", "download-bytes", "wrong-state")
+        for case in cases:
+            with self.subTest(case=case):
+                self._write_stubs()
+                if case == "api-digest":
+                    identity = json.loads(
+                        (self.root / "archive-identity.json").read_text()
+                    )
+                    identity["digest"] = "sha256:" + "f" * 64
+                    (self.root / "archive-identity.json").write_text(
+                        json.dumps(identity)
+                    )
+                elif case == "download-bytes":
+                    self.archive.write_bytes(self.archive.read_bytes() + b"tamper")
+                else:
+                    release = json.loads((self.root / "release.json").read_text())
+                    release["assets"][0]["state"] = "starter"
+                    (self.root / "release.json").write_text(json.dumps(release))
+                result = self.run_collector()
+                self.assertEqual(result.returncode, 0, result.stderr)
+                report = json.loads(result.stdout)
+                self.assertFalse(report["release"]["valid"])
+                self.assertIsNone(report["release"]["archive_validation"])
+                self.assertEqual(report["overall_status"], "degraded")
+                if case == "download-bytes":
+                    self.archive = build_archive(self.archive)
+
+    def test_malformed_manifest_validator_document_is_preserved_and_degraded(self):
+        self.manifest.write_text("{}\n", encoding="utf-8")
+        self._write_stubs()
+        result = self.run_collector()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertEqual(
+            report["release"]["archive_validation"],
+            {"ok": False, "error": "invalid-manifest"},
+        )
+        self.assertFalse(report["release"]["valid"])
+        self.assertEqual(report["overall_status"], "degraded")
+
+    def test_fatal_collector_preflight_has_empty_stdout(self):
+        (self.deployed_scripts / "validate_archive.py").unlink()
+        result = self.run_collector()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("validator", result.stderr.lower())
+
+    def test_complete_not_due_report_exits_zero(self):
+        self._write_executable(
+            "date",
+            """#!/usr/bin/env bash
+case "$*" in
+  +%F) printf '%s\n' '2026-07-20' ;;
+  '+%Y-%m-%d %H:%M:%S %Z %z') printf '%s\n' '2026-07-20 12:00:00 CST +0800' ;;
+  +%H%M) printf '%s\n' '1200' ;;
+  '-u +%s') printf '%s\n' '1784520000' ;;
+  *) /usr/bin/date "$@" ;;
+esac
+""",
+        )
+        result = self.run_collector()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["overall_status"], "not_due")
+
+
+class DeployRollbackSimulationTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.source = self.root / "source"
+        self.target = self.root / "skill"
+        self.merged = self.root / "merged-skill"
+        self.rollback = self.root / ".rollback-148"
+        (self.source / "scripts").mkdir(parents=True)
+        (self.target / "scripts").mkdir(parents=True)
+        (self.source / "SKILL.md").write_text("new skill\n")
+        (self.source / "scripts/collect_health.sh").write_text(
+            '#!/usr/bin/env bash\nprintf \'%s\\n\' \'{"release":{"archive_validation":{"ok":true}}}\'\n'
+        )
+        shutil.copy2(VALIDATOR, self.source / "scripts/validate_archive.py")
+        (self.target / "SKILL.md").write_text("old skill\n")
+        (self.target / "scripts/collect_health.sh").write_text("#!/usr/bin/env bash\nprintf 'old\\n'\n")
+        (self.target / "scripts/notify_feishu.sh").write_text("#!/usr/bin/env bash\nprintf 'notify\\n'\n")
+        (self.target / COMPATIBILITY_LINK_NAME).symlink_to(COMPATIBILITY_LINK_TARGET)
+        self.merged.symlink_to(self.target, target_is_directory=True)
+        os.chmod(self.source / "SKILL.md", 0o644)
+        os.chmod(self.source / "scripts/collect_health.sh", 0o755)
+        os.chmod(self.source / "scripts/validate_archive.py", 0o755)
+        os.chmod(self.target / "SKILL.md", 0o644)
+        os.chmod(self.target / "scripts/collect_health.sh", 0o700)
+        os.chmod(self.target / "scripts/notify_feishu.sh", 0o700)
+        self.old_skill_digest = hashlib.sha256(
+            (self.target / "SKILL.md").read_bytes()
+        ).hexdigest()
+        self.old_collector_digest = hashlib.sha256(
+            (self.target / "scripts/collect_health.sh").read_bytes()
+        ).hexdigest()
+        self.notifier_digest = hashlib.sha256((self.target / "scripts/notify_feishu.sh").read_bytes()).hexdigest()
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def run_function(self, function, *args):
+        command = [
+            "bash",
+            "-c",
+            (
+                'source "$1"; shift; '
+                'AUTHORIZED_OLD_SKILL_SHA256="$TEST_OLD_SKILL_SHA256"; '
+                'AUTHORIZED_OLD_COLLECTOR_SHA256="$TEST_OLD_COLLECTOR_SHA256"; '
+                'AUTHORIZED_NOTIFIER_SHA256="$TEST_NOTIFIER_SHA256"; '
+                'function_name=$1; shift; "$function_name" "$@"'
+            ),
+            "bash",
+            str(ROOT / "ops/investment-data-project-monitor/deploy.sh"),
+            function,
+            *map(str, args),
+        ]
+        return subprocess.run(
+            command,
+            text=True,
+            capture_output=True,
+            env={
+                **os.environ,
+                "TEST_OLD_SKILL_SHA256": self.old_skill_digest,
+                "TEST_OLD_COLLECTOR_SHA256": self.old_collector_digest,
+                "TEST_NOTIFIER_SHA256": self.notifier_digest,
+            },
+        )
+
+    def run_guarded_function(self, function, *args):
+        command = [
+            "bash",
+            "-c",
+            (
+                'source "$1"; shift; function_name=$1; shift; '
+                'AUTHORIZED_OLD_SKILL_SHA256="$TEST_OLD_SKILL_SHA256"; '
+                'AUTHORIZED_OLD_COLLECTOR_SHA256="$TEST_OLD_COLLECTOR_SHA256"; '
+                'AUTHORIZED_NOTIFIER_SHA256="$TEST_NOTIFIER_SHA256"; '
+                'if ! "$function_name" "$@"; then exit 0; fi; exit 97'
+            ),
+            "bash",
+            str(ROOT / "ops/investment-data-project-monitor/deploy.sh"),
+            function,
+            *map(str, args),
+        ]
+        return subprocess.run(
+            command,
+            text=True,
+            capture_output=True,
+            env={
+                **os.environ,
+                "TEST_OLD_SKILL_SHA256": self.old_skill_digest,
+                "TEST_OLD_COLLECTOR_SHA256": self.old_collector_digest,
+                "TEST_NOTIFIER_SHA256": self.notifier_digest,
+            },
+        )
+
+    def snapshot_tree(self, root):
+        snapshot = []
+        if not root.exists() and not root.is_symlink():
+            return snapshot
+        for path in sorted(root.rglob("*"), key=lambda value: value.as_posix()):
+            relative = path.relative_to(root).as_posix()
+            mode = path.lstat().st_mode & 0o7777
+            if path.is_symlink():
+                snapshot.append((relative, "link", mode, os.readlink(path)))
+            elif path.is_dir():
+                snapshot.append((relative, "dir", mode, None))
+            else:
+                snapshot.append(
+                    (
+                        relative,
+                        "file",
+                        mode,
+                        hashlib.sha256(path.read_bytes()).hexdigest(),
+                    )
+                )
+        return snapshot
+
+    def run_interrupted_function(self, checkpoint, function, *args):
+        marker = self.root / ("checkpoint-" + checkpoint)
+        command = [
+            "bash",
+            "-c",
+            r'''
+              source "$1"; shift
+              AUTHORIZED_OLD_SKILL_SHA256="$TEST_OLD_SKILL_SHA256"
+              AUTHORIZED_OLD_COLLECTOR_SHA256="$TEST_OLD_COLLECTOR_SHA256"
+              AUTHORIZED_NOTIFIER_SHA256="$TEST_NOTIFIER_SHA256"
+              wanted=$1; marker=$2; function_name=$3; shift 3
+              deploy_checkpoint() {
+                if [[ "$1" == "$wanted" && ! -e "$marker" ]]; then
+                  : >"$marker"
+                  exit 99
+                fi
+              }
+              "$function_name" "$@"
+            ''',
+            "bash",
+            str(ROOT / "ops/investment-data-project-monitor/deploy.sh"),
+            checkpoint,
+            str(marker),
+            function,
+            *map(str, args),
+        ]
+        return subprocess.run(
+            command,
+            text=True,
+            capture_output=True,
+            env={
+                **os.environ,
+                "TEST_OLD_SKILL_SHA256": self.old_skill_digest,
+                "TEST_OLD_COLLECTOR_SHA256": self.old_collector_digest,
+                "TEST_NOTIFIER_SHA256": self.notifier_digest,
+            },
+        )
+
+    def deploy(self):
+        return self.run_function(
+            "deploy_paths",
+            self.source / "SKILL.md",
+            self.source / "scripts/collect_health.sh",
+            self.source / "scripts/validate_archive.py",
+            self.target,
+            self.merged,
+            self.rollback,
+        )
+
+    def test_success_rerun_mixed_state_and_idempotent_rollback(self):
+        old_skill = (self.target / "SKILL.md").read_bytes()
+        old_collector = (self.target / "scripts/collect_health.sh").read_bytes()
+        old_notifier = (self.target / "scripts/notify_feishu.sh").read_bytes()
+        result = self.deploy()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue((self.target / "scripts/validate_archive.py").exists())
+        self.assertEqual((self.target / "SKILL.md").read_text(), "new skill\n")
+        self.assertEqual(hashlib.sha256((self.target / "scripts/notify_feishu.sh").read_bytes()).hexdigest(), self.notifier_digest)
+        self.assertTrue(self.rollback.is_dir())
+        self.assertFalse((self.rollback / "scripts/validate_archive.py").exists())
+        self.assertFalse(Path(str(self.rollback) + ".next").exists())
+        self.assertEqual((self.rollback / "SKILL.md").read_bytes(), old_skill)
+        self.assertEqual(
+            (self.rollback / "scripts/collect_health.sh").read_bytes(), old_collector
+        )
+        self.assertEqual(
+            (self.rollback / "scripts/notify_feishu.sh").read_bytes(), old_notifier
+        )
+        self.assertEqual(os.stat(self.rollback / "SKILL.md").st_mode & 0o777, 0o644)
+        self.assertEqual(
+            os.stat(self.rollback / "scripts/collect_health.sh").st_mode & 0o777,
+            0o700,
+        )
+        self.assertEqual(
+            os.stat(self.rollback / "scripts/notify_feishu.sh").st_mode & 0o777,
+            0o700,
+        )
+        self.assertEqual(os.readlink(self.target / COMPATIBILITY_LINK_NAME), COMPATIBILITY_LINK_TARGET)
+        self.assertEqual(os.readlink(self.rollback / COMPATIBILITY_LINK_NAME), COMPATIBILITY_LINK_TARGET)
+
+        shutil.copy2(self.rollback / "SKILL.md", self.target / "SKILL.md")
+        shutil.copy2(self.rollback / "scripts/collect_health.sh", self.target / "scripts/collect_health.sh")
+        result = self.deploy()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual((self.target / "SKILL.md").read_text(), "new skill\n")
+
+        for _ in range(2):
+            result = self.run_function("rollback_paths", self.target, self.merged, self.rollback)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual((self.target / "SKILL.md").read_text(), "old skill\n")
+            self.assertFalse((self.target / "scripts/validate_archive.py").exists())
+            self.assertEqual(hashlib.sha256((self.target / "scripts/notify_feishu.sh").read_bytes()).hexdigest(), self.notifier_digest)
+            self.assertEqual(os.readlink(self.target / COMPATIBILITY_LINK_NAME), COMPATIBILITY_LINK_TARGET)
+
+    def test_rollback_inventory_rejects_an_unexpected_validator(self):
+        result = self.deploy()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        shutil.copy2(
+            self.source / "scripts/validate_archive.py",
+            self.rollback / "scripts/validate_archive.py",
+        )
+        target_skill = (self.target / "SKILL.md").read_bytes()
+        target_validator = (self.target / "scripts/validate_archive.py").read_bytes()
+
+        result = self.run_guarded_function(
+            "restore_from_rollback", self.target, self.merged, self.rollback
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual((self.target / "SKILL.md").read_bytes(), target_skill)
+        self.assertEqual(
+            (self.target / "scripts/validate_archive.py").read_bytes(),
+            target_validator,
+        )
+
+    def test_existing_rollback_with_byte_different_old_file_is_rejected(self):
+        result = self.deploy()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        (self.rollback / "SKILL.md").write_text("different but structurally valid\n")
+        os.chmod(self.rollback / "SKILL.md", 0o644)
+        before = self.snapshot_tree(self.target)
+        result = self.deploy()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(self.snapshot_tree(self.target), before)
+
+    def test_preflight_failures_do_not_mutate_target_or_create_rollback(self):
+        cases = ("notifier-hash", "unexpected-inventory", "bad-source-shell", "bad-stage-type")
+        for case in cases:
+            with self.subTest(case=case):
+                case_root = self.root / case
+                source = case_root / "source"
+                target = case_root / "skill"
+                merged = case_root / "merged"
+                rollback = case_root / ".rollback"
+                shutil.copytree(self.source, source)
+                shutil.copytree(self.target, target, symlinks=True)
+                merged.symlink_to(target, target_is_directory=True)
+                if case == "notifier-hash":
+                    (target / "scripts/notify_feishu.sh").write_text("tampered notifier\n")
+                    os.chmod(target / "scripts/notify_feishu.sh", 0o700)
+                elif case == "unexpected-inventory":
+                    (target / "unexpected").write_text("unexpected\n")
+                elif case == "bad-source-shell":
+                    (source / "scripts/collect_health.sh").write_text("if broken\n")
+                    os.chmod(source / "scripts/collect_health.sh", 0o755)
+                else:
+                    (target / "scripts/collect_health.sh.next").mkdir()
+                before = self.snapshot_tree(target)
+                result = self.run_function(
+                    "deploy_paths",
+                    source / "SKILL.md",
+                    source / "scripts/collect_health.sh",
+                    source / "scripts/validate_archive.py",
+                    target,
+                    merged,
+                    rollback,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(self.snapshot_tree(target), before)
+                self.assertFalse(rollback.exists())
+                self.assertFalse(Path(str(rollback) + ".next").exists())
+
+    def test_every_deploy_checkpoint_reruns_to_verified_success(self):
+        checkpoints = (
+            "rollback-copy-created",
+            "rollback-copy-verified",
+            "rollback-copy-promoted",
+            "install-validator-staged",
+            "install-validator-verified",
+            "install-validator-promoted",
+            "install-collector-staged",
+            "install-collector-verified",
+            "install-collector-promoted",
+            "install-skill-staged",
+            "install-skill-verified",
+            "install-skill-promoted",
+            "acceptance-physical-verified",
+            "acceptance-merged-verified",
+            "acceptance-validator-fixtures",
+            "acceptance-collector-report",
+        )
+        for checkpoint in checkpoints:
+            with self.subTest(checkpoint=checkpoint):
+                case_root = self.root / checkpoint
+                target = case_root / "skill"
+                merged = case_root / "merged"
+                rollback = case_root / ".rollback"
+                shutil.copytree(self.target, target, symlinks=True)
+                merged.symlink_to(target, target_is_directory=True)
+                interrupted = self.run_interrupted_function(
+                    checkpoint,
+                    "deploy_paths",
+                    self.source / "SKILL.md",
+                    self.source / "scripts/collect_health.sh",
+                    self.source / "scripts/validate_archive.py",
+                    target,
+                    merged,
+                    rollback,
+                )
+                self.assertEqual(interrupted.returncode, 99, interrupted.stderr)
+                resumed = self.run_function(
+                    "deploy_paths",
+                    self.source / "SKILL.md",
+                    self.source / "scripts/collect_health.sh",
+                    self.source / "scripts/validate_archive.py",
+                    target,
+                    merged,
+                    rollback,
+                )
+                self.assertEqual(resumed.returncode, 0, resumed.stderr)
+                self.assertEqual(
+                    hashlib.sha256((target / "SKILL.md").read_bytes()).hexdigest(),
+                    hashlib.sha256((self.source / "SKILL.md").read_bytes()).hexdigest(),
+                )
+                self.assertTrue((target / "scripts/validate_archive.py").is_file())
+
+    def test_every_restore_checkpoint_reruns_to_exact_prevalidator_tree(self):
+        checkpoints = (
+            "restore-collector-staged",
+            "restore-collector-verified",
+            "restore-collector-promoted",
+            "restore-skill-staged",
+            "restore-skill-verified",
+            "restore-skill-promoted",
+            "restore-validator-parked",
+            "restore-old-views-reverified",
+            "restore-validator-removed",
+        )
+        for checkpoint in checkpoints:
+            with self.subTest(checkpoint=checkpoint):
+                case_root = self.root / ("restore-" + checkpoint)
+                target = case_root / "skill"
+                merged = case_root / "merged"
+                rollback = case_root / ".rollback"
+                shutil.copytree(self.target, target, symlinks=True)
+                merged.symlink_to(target, target_is_directory=True)
+                deployed = self.run_function(
+                    "deploy_paths",
+                    self.source / "SKILL.md",
+                    self.source / "scripts/collect_health.sh",
+                    self.source / "scripts/validate_archive.py",
+                    target,
+                    merged,
+                    rollback,
+                )
+                self.assertEqual(deployed.returncode, 0, deployed.stderr)
+                interrupted = self.run_interrupted_function(
+                    checkpoint,
+                    "restore_from_rollback",
+                    target,
+                    merged,
+                    rollback,
+                )
+                self.assertEqual(interrupted.returncode, 99, interrupted.stderr)
+                resumed = self.run_function(
+                    "rollback_paths", target, merged, rollback
+                )
+                self.assertEqual(resumed.returncode, 0, resumed.stderr)
+                self.assertEqual(
+                    hashlib.sha256((target / "SKILL.md").read_bytes()).hexdigest(),
+                    self.old_skill_digest,
+                )
+                self.assertEqual(
+                    hashlib.sha256(
+                        (target / "scripts/collect_health.sh").read_bytes()
+                    ).hexdigest(),
+                    self.old_collector_digest,
+                )
+                self.assertFalse((target / "scripts/validate_archive.py").exists())
+
+    def test_acceptance_failure_restores_exact_old_inventory(self):
+        (self.source / "scripts/collect_health.sh").write_text(
+            '#!/usr/bin/env bash\nprintf \'%s\\n\' \'{"release":{"archive_validation":{"ok":false}}}\'\n'
+        )
+        os.chmod(self.source / "scripts/collect_health.sh", 0o755)
+        result = self.deploy()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual((self.target / "SKILL.md").read_text(), "old skill\n")
+        self.assertEqual((self.target / "scripts/collect_health.sh").read_text(), "#!/usr/bin/env bash\nprintf 'old\\n'\n")
+        self.assertFalse((self.target / "scripts/validate_archive.py").exists())
+        self.assertEqual(hashlib.sha256((self.target / "scripts/notify_feishu.sh").read_bytes()).hexdigest(), self.notifier_digest)
+
+    def test_actual_collector_healthy_fixture_passes_physical_and_merged_acceptance(self):
+        fixture = CollectorFixtureTest("test_valid_pair_is_downloaded_and_validator_document_is_preserved")
+        fixture.setUp()
+        try:
+            shutil.copy2(
+                ROOT / "ops/investment-data-project-monitor/collect_health.sh",
+                self.source / "scripts/collect_health.sh",
+            )
+            os.chmod(self.source / "scripts/collect_health.sh", 0o755)
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "HOME": str(fixture.home),
+                    "FIXTURE_ROOT": str(fixture.root),
+                    "FIXTURE_ARCHIVE": str(fixture.archive),
+                    "FIXTURE_MANIFEST": str(fixture.manifest),
+                },
+            ):
+                result = self.deploy()
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                hashlib.sha256(
+                    (self.target / "scripts/collect_health.sh").read_bytes()
+                ).hexdigest(),
+                hashlib.sha256(
+                    (self.source / "scripts/collect_health.sh").read_bytes()
+                ).hexdigest(),
+            )
+            self.assertEqual(
+                hashlib.sha256(
+                    (self.merged / "scripts/validate_archive.py").read_bytes()
+                ).hexdigest(),
+                hashlib.sha256(VALIDATOR.read_bytes()).hexdigest(),
+            )
+        finally:
+            fixture.tearDown()
+
+    def test_actual_collector_degraded_fixture_restores_prevalidator_tree(self):
+        fixture = CollectorFixtureTest("test_validator_semantic_failure_is_unmodified_and_invalid")
+        fixture.setUp()
+        try:
+            members = dict(REQUIRED)
+            members["qlib_bin/instruments/csi300.txt"] = (
+                "sh600000\t2026-07-17\t2026-07-17\n"
+            )
+            fixture.archive = build_archive(fixture.archive, members)
+            payload = json.loads(fixture.manifest.read_text())
+            payload["archive_size_bytes"] = fixture.archive.stat().st_size
+            payload["archive_sha256"] = (
+                "sha256:" + hashlib.sha256(fixture.archive.read_bytes()).hexdigest()
+            )
+            write_manifest(fixture.manifest, payload)
+            fixture._write_stubs()
+            shutil.copy2(
+                ROOT / "ops/investment-data-project-monitor/collect_health.sh",
+                self.source / "scripts/collect_health.sh",
+            )
+            os.chmod(self.source / "scripts/collect_health.sh", 0o755)
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "HOME": str(fixture.home),
+                    "FIXTURE_ROOT": str(fixture.root),
+                    "FIXTURE_ARCHIVE": str(fixture.archive),
+                    "FIXTURE_MANIFEST": str(fixture.manifest),
+                },
+            ):
+                result = self.deploy()
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(
+                hashlib.sha256((self.target / "SKILL.md").read_bytes()).hexdigest(),
+                self.old_skill_digest,
+            )
+            self.assertEqual(
+                hashlib.sha256(
+                    (self.target / "scripts/collect_health.sh").read_bytes()
+                ).hexdigest(),
+                self.old_collector_digest,
+            )
+            self.assertFalse((self.target / "scripts/validate_archive.py").exists())
+        finally:
+            fixture.tearDown()
+
+    def test_rerun_finishes_exact_parked_validator_restore_transition(self):
+        result = self.deploy()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        shutil.copy2(self.rollback / "SKILL.md", self.target / "SKILL.md")
+        shutil.copy2(
+            self.rollback / "scripts/collect_health.sh",
+            self.target / "scripts/collect_health.sh",
+        )
+        validator = self.target / "scripts/validate_archive.py"
+        parked = self.target / "scripts/validate_archive.py.next"
+        validator.rename(parked)
+
+        result = self.deploy()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(parked.exists())
+        self.assertTrue(validator.exists())
+        self.assertEqual((self.target / "SKILL.md").read_text(), "new skill\n")
+
+    def test_inventory_accepts_only_the_exact_compatibility_link(self):
+        good = self.run_function("verify_inventory", self.target, "false")
+        self.assertEqual(good.returncode, 0, good.stderr)
+
+        for case in ("absent", "wrong-type", "wrong-target"):
+            with self.subTest(case=case):
+                case_root = self.root / f"compatibility-{case}"
+                source = case_root / "source"
+                target = case_root / "skill"
+                merged = case_root / "merged"
+                rollback = case_root / ".rollback"
+                shutil.copytree(self.source, source)
+                shutil.copytree(self.target, target, symlinks=True)
+                merged.symlink_to(target, target_is_directory=True)
+                link = target / COMPATIBILITY_LINK_NAME
+                link.unlink()
+                if case == "wrong-type":
+                    link.write_text(COMPATIBILITY_LINK_TARGET + "\n", encoding="utf-8")
+                elif case == "wrong-target":
+                    link.symlink_to("/tmp/not-the-merged-view")
+                before = self.snapshot_tree(target)
+                result = self.run_function(
+                    "deploy_paths",
+                    source / "SKILL.md",
+                    source / "scripts/collect_health.sh",
+                    source / "scripts/validate_archive.py",
+                    target,
+                    merged,
+                    rollback,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(self.snapshot_tree(target), before)
+                self.assertFalse(rollback.exists())
+                self.assertFalse(Path(str(rollback) + ".next").exists())
+
+        unexpected = self.root / "unexpected-skill"
+        shutil.copytree(self.target, unexpected, symlinks=True)
+        (unexpected / "unexpected.txt").write_text("unexpected\n")
+        result = self.run_guarded_function("verify_inventory", unexpected, "false")
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_install_failure_is_not_masked_beneath_negated_conditional(self):
+        result = self.deploy()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        destination = self.target / "scripts/collect_health.sh"
+        destination.write_text("#!/usr/bin/env bash\nprintf 'third identity\\n'\n")
+        before = destination.read_bytes()
+        result = self.run_guarded_function(
+            "install_one",
+            self.source / "scripts/collect_health.sh",
+            destination,
+            self.rollback / "scripts/collect_health.sh",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(destination.read_bytes(), before)
+
+    def test_merged_view_failure_is_not_masked_by_later_acceptance_checks(self):
+        result = self.deploy()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        stale_merged = self.root / "stale-merged"
+        shutil.copytree(self.target, stale_merged, symlinks=True)
+        (stale_merged / "SKILL.md").write_text("stale merged instructions\n")
+        os.chmod(stale_merged / "SKILL.md", 0o644)
+        result = self.run_guarded_function(
+            "accept_deployment",
+            self.source / "SKILL.md",
+            self.source / "scripts/collect_health.sh",
+            self.source / "scripts/validate_archive.py",
+            self.target,
+            stale_merged,
+            self.rollback,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_restore_precheck_failure_is_not_masked_or_installed(self):
+        result = self.deploy()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        target_before = (self.target / "SKILL.md").read_bytes()
+        os.chmod(self.rollback / "SKILL.md", 0o600)
+        result = self.run_guarded_function(
+            "restore_from_rollback", self.target, self.merged, self.rollback
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual((self.target / "SKILL.md").read_bytes(), target_before)
+
+
+@unittest.skipUnless(
+    os.environ.get("QLIB_REAL_BUILD_A") and os.environ.get("QLIB_REAL_BUILD_B"),
+    "two independent real production build directories were not supplied",
+)
+class RealProductionBuildEvidenceTest(unittest.TestCase):
+    def test_independent_fixed_snapshot_builds_are_byte_and_member_identical(self):
+        roots = [
+            Path(os.environ["QLIB_REAL_BUILD_A"]),
+            Path(os.environ["QLIB_REAL_BUILD_B"]),
+        ]
+        archives = [root / "qlib_bin.tar.gz" for root in roots]
+        manifests = [root / "qlib_bin.manifest.json" for root in roots]
+
+        validator_results = []
+        for archive, manifest in zip(archives, manifests):
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(VALIDATOR),
+                    "--archive",
+                    str(archive),
+                    "--manifest",
+                    str(manifest),
+                    "--expected-tag",
+                    "2026-07-20",
+                    "--require-publishable",
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            validator_result = json.loads(result.stdout)
+            self.assertEqual(
+                result.stdout,
+                json.dumps(validator_result, separators=(",", ":")) + "\n",
+            )
+            validator_results.append(validator_result)
+
+        self.assertEqual(archives[0].read_bytes(), archives[1].read_bytes())
+        self.assertEqual(manifests[0].read_bytes(), manifests[1].read_bytes())
+
+        payload = json.loads(manifests[0].read_bytes())
+        self.assertEqual(
+            payload,
+            {
+                "release_tag": "2026-07-20",
+                "target_trade_date": "2026-07-20",
+                "future_start_date": "2026-07-21",
+                "future_end_date": "2026-12-31",
+                "dolt_commit": os.environ["QLIB_REAL_DOLT_COMMIT"],
+                "investment_data_commit": os.environ["QLIB_REAL_REPOSITORY_COMMIT"],
+                "qlib_commit": QLIB_COMMIT,
+                "image_digest": os.environ["QLIB_REAL_IMAGE_DIGEST"],
+                "archive_size_bytes": archives[0].stat().st_size,
+                "archive_sha256": "sha256:"
+                + hashlib.sha256(archives[0].read_bytes()).hexdigest(),
+            },
+        )
+        self.assertEqual(
+            manifests[0].read_bytes(),
+            (json.dumps(payload, separators=(",", ":")) + "\n").encode(),
+        )
+        expected_validator_result = {
+            "ok": True,
+            "result": {
+                "archive_sha256": payload["archive_sha256"],
+                "manifest_sha256": "sha256:"
+                + hashlib.sha256(manifests[0].read_bytes()).hexdigest(),
+                "archive_size_bytes": payload["archive_size_bytes"],
+                "target_trade_date": payload["target_trade_date"],
+                "future_start_date": payload["future_start_date"],
+                "future_end_date": payload["future_end_date"],
+            },
+        }
+        self.assertEqual(validator_results, [expected_validator_result] * 2)
+
+        def ordered_members(path):
+            result = []
+            with tarfile.open(path, "r:gz") as stream:
+                for member in stream:
+                    body_hash = None
+                    if member.isfile():
+                        body = stream.extractfile(member)
+                        self.assertIsNotNone(body)
+                        body_hash = hashlib.sha256(body.read()).hexdigest()
+                    result.append(
+                        (
+                            member.name,
+                            member.type,
+                            member.mode,
+                            member.uid,
+                            member.gid,
+                            member.mtime,
+                            member.size,
+                            body_hash,
+                        )
+                    )
+            return result
+
+        first = ordered_members(archives[0])
+        second = ordered_members(archives[1])
+        self.assertTrue(first)
+        self.assertEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tushare/dump_day_calendar.py
+++ b/tushare/dump_day_calendar.py
@@ -1,27 +1,73 @@
-from sqlalchemy import create_engine
-import pymysql
-import pandas as pd
-import fire
-import os
 import datetime
 from pathlib import Path
+from typing import Optional
 
-def dump_calendar_to_qlib_dir(qlib_dir, skip_exists=False):
-  sqlEngine = create_engine('mysql+pymysql://root:@127.0.0.1/investment_data', pool_recycle=3600)
-  dbConnection = sqlEngine.raw_connection()
+import fire
+import pandas as pd
+from sqlalchemy import create_engine
 
-  old_days_file =Path(qlib_dir) / "calendars/day.txt"
-  old_calendar_df = pd.read_csv(old_days_file, header=None)
-  min_date = pd.to_datetime(old_calendar_df.iloc[0][0])
 
-  filename = Path(qlib_dir) / "calendars/day_future.txt"
+def _validate_target_trade_date(target_trade_date: Optional[str]) -> Optional[str]:
+  if target_trade_date is None:
+    return None
+  if not isinstance(target_trade_date, str):
+    raise ValueError("target_trade_date must be YYYY-MM-DD")
+  try:
+    parsed = datetime.datetime.strptime(target_trade_date, "%Y-%m-%d")
+  except ValueError as exc:
+    raise ValueError("target_trade_date must be YYYY-MM-DD") from exc
+  if parsed.strftime("%Y-%m-%d") != target_trade_date:
+    raise ValueError("target_trade_date must be YYYY-MM-DD")
+  return target_trade_date
+
+
+def dump_calendar_to_qlib_dir(
+    qlib_dir,
+    skip_exists=False,
+    target_trade_date: Optional[str] = None,
+):
+  del skip_exists  # Retained for Fire compatibility.
+  target_trade_date = _validate_target_trade_date(target_trade_date)
+
+  qlib_path = Path(qlib_dir)
+  day_path = qlib_path / "calendars/day.txt"
+  old_calendar = [line for line in day_path.read_text(encoding="utf-8").splitlines() if line]
+  if not old_calendar:
+    raise ValueError("Current qlib calendar is empty")
+  min_date = pd.Timestamp(old_calendar[0]).strftime("%Y-%m-%d")
+  current_end = pd.Timestamp(old_calendar[-1]).strftime("%Y-%m-%d")
+  if target_trade_date is not None and current_end != target_trade_date:
+    raise ValueError(
+        f"Current qlib calendar ends at {current_end}, expected {target_trade_date}"
+    )
+
+  sql_engine = create_engine(
+      "mysql+pymysql://root:@127.0.0.1/investment_data", pool_recycle=3600
+  )
+  db_connection = sql_engine.raw_connection()
+  try:
+    sql = f"""
+      SELECT date
+      FROM ts_trade_day_calendar
+      WHERE exchange = 'SSE' AND is_open = 1 AND date >= '{min_date}'
+      ORDER BY date
+    """
+    calendar_df = pd.read_sql(sql, db_connection)
+  finally:
+    db_connection.close()
+    sql_engine.dispose()
+
+  dates = [pd.Timestamp(value).strftime("%Y-%m-%d") for value in calendar_df["date"]]
+  if not dates or dates != sorted(set(dates)):
+    raise ValueError("Future calendar dates must be nonempty, ordered, and unique")
+  if target_trade_date is not None and target_trade_date not in dates:
+    raise ValueError(f"Target trade date {target_trade_date} is absent from the calendar")
+
+  filename = qlib_path / "calendars/day_future.txt"
   print("Dumping to file: ", filename)
-  sql = "select date from ts_trade_day_calendar WHERE exchange = 'SSE' AND is_open = 1;"
-  calendar_df = pd.read_sql(sql, dbConnection)
-  calendar_df["date"] = pd.to_datetime(calendar_df["date"])
-  calendar_df.drop(calendar_df[calendar_df["date"] < min_date].index, inplace=True)
+  with filename.open("w", encoding="utf-8", newline="\n") as stream:
+    stream.write("".join(f"{value}\n" for value in dates))
 
-  calendar_df.to_csv(filename, index=False, header=False, sep='\t')
 
 if __name__ == "__main__":
   fire.Fire(dump_calendar_to_qlib_dir)

--- a/upload_release.sh
+++ b/upload_release.sh
@@ -1,126 +1,1153 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Configure git proxy if http_proxy or https_proxy are set
-if [[ -n "${http_proxy-}" ]]; then
-  git config --global http.proxy "${http_proxy}"
+REPOSITORY="chenditc/investment_data"
+API_ROOT="https://api.github.com/repos/${REPOSITORY}"
+UPLOAD_ROOT="https://uploads.github.com/repos/${REPOSITORY}"
+PUBLISHER_LOCK="/tmp/investment-data-release-publisher.lock"
+QLIB_COMMIT="b87a2c294d364a33fb739359886acffe8ec907d1"
+REPOSITORY_REVISION_FILE="/opt/investment-data/REVISION"
+QLIB_REVISION_FILE="/opt/investment-data/QLIB_REVISION"
+FIXED_TAG="2026-07-20"
+FIXED_DOLT_COMMIT="9vtplc2tar9ver7p6s1bus2oiedjvtqo"
+FIXED_RELEASE_ID=356733573
+FIXED_ORIGINAL_ASSET_ID=483488955
+FIXED_ORIGINAL_SIZE=558140106
+FIXED_ORIGINAL_DIGEST="sha256:1b1c073af75b69fecff85654cb020aa813c2d1761cab51048845140ae2cd2510"
+FIXED_ORIGINAL_CREATED_AT="2026-07-20T13:26:30Z"
+FIXED_ORIGINAL_UPDATED_AT="2026-07-20T13:26:48Z"
+BACKUP_NAME="qlib_bin.original-2026-07-20-483488955.tar.gz"
+RECEIPT_NAME="qlib-repair-2026-07-20.json"
+ARCHIVE_NAME="qlib_bin.tar.gz"
+MANIFEST_NAME="qlib_bin.manifest.json"
+WORK_DIR=""
+ORIGIN_AUTHORITY_VERIFIED=false
+
+die() {
+    printf 'Error: %s\n' "$*" >&2
+    return 1
+}
+
+usage() {
+    printf 'usage: %s [repair-2026-07-20]\n' "${0##*/}" >&2
+}
+
+sha256_file() {
+    local digest
+    digest="$(sha256sum "$1" | awk '{print $1}')" || return 1
+    printf 'sha256:%s\n' "$digest"
+}
+
+file_size() {
+    stat -c%s "$1"
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 \
+        || { die "required command is unavailable: $1"; return 1; }
+}
+
+github_api_get() {
+    curl -fsSL --retry 3 --retry-delay 2 \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -H "Accept: application/vnd.github+json" \
+        "${API_ROOT}$1"
+}
+
+github_get_release_by_tag_optional() {
+    local tag=$1 response_file status
+    response_file="$(mktemp "$WORK_DIR/api.XXXXXXXX")" || return 1
+    status="$(curl -sSL -o "$response_file" -w '%{http_code}' \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -H "Accept: application/vnd.github+json" \
+        "${API_ROOT}/releases/tags/${tag}")" || return 1
+    case "$status" in
+        200) cat "$response_file" || return 1 ;;
+        404) return 4 ;;
+        *) die "GitHub release lookup failed with HTTP $status"; return 1 ;;
+    esac
+}
+
+github_get_asset_by_id_optional() {
+    local asset_id=$1 response_file status
+    response_file="$(mktemp "$WORK_DIR/api.XXXXXXXX")" || return 1
+    status="$(curl -sSL -o "$response_file" -w '%{http_code}' \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -H "Accept: application/vnd.github+json" \
+        "${API_ROOT}/releases/assets/${asset_id}")" || return 1
+    case "$status" in
+        200) cat "$response_file" || return 1 ;;
+        404) return 4 ;;
+        *) die "GitHub asset lookup failed with HTTP $status"; return 1 ;;
+    esac
+}
+
+github_create_release() {
+    local tag=$1 payload
+    payload="$(jq -cn --arg tag "$tag" \
+        '{tag_name:$tag,name:$tag,body:"Daily update release",draft:false,prerelease:false}')" \
+        || return 1
+    curl -fsSL --retry 3 --retry-delay 2 \
+        -X POST \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -H "Accept: application/vnd.github+json" \
+        -H 'Content-Type: application/json' \
+        --data-binary "$payload" \
+        "${API_ROOT}/releases"
+}
+
+github_upload_asset() {
+    local release_id=$1 name=$2 path=$3 content_type=$4
+    curl -fsSL \
+        -X POST \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -H "Content-Type: ${content_type}" \
+        --data-binary "@${path}" \
+        "${UPLOAD_ROOT}/releases/${release_id}/assets?name=${name}"
+}
+
+github_download_asset() {
+    local asset_id=$1 destination=$2
+    curl -fsSL --retry 3 --retry-delay 2 \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -H "Accept: application/octet-stream" \
+        -o "$destination" \
+        "${API_ROOT}/releases/assets/${asset_id}"
+}
+
+github_delete_asset() {
+    local asset_id=$1
+    curl -fsSL \
+        -X DELETE \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "${API_ROOT}/releases/assets/${asset_id}" >/dev/null
+}
+
+list_assets() {
+    github_api_get "/releases/${RELEASE_ID}/assets?per_page=100"
+}
+
+slot_json() {
+    local assets=$1 name=$2 count
+    count="$(jq --arg name "$name" '[.[] | select(.name == $name)] | length' <<<"$assets")" \
+        || return 1
+    ((count <= 1)) \
+        || { die "duplicate release assets named $name"; return 1; }
+    if ((count == 0)); then
+        printf 'null\n'
+    else
+        jq -c --arg name "$name" '.[] | select(.name == $name)' <<<"$assets" \
+            || return 1
+    fi
+}
+
+slot_state() {
+    local asset=$1 state size
+    if [[ "$asset" == "null" ]]; then
+        printf 'absent\n'
+        return
+    fi
+    state="$(jq -r '.state' <<<"$asset")" || return 1
+    size="$(jq -r '.size' <<<"$asset")" || return 1
+    case "$state" in
+        uploaded)
+            [[ "$size" =~ ^[1-9][0-9]*$ ]] \
+                || { die "uploaded asset has invalid size"; return 1; }
+            printf 'uploaded\n'
+            ;;
+        starter)
+            [[ "$size" == "0" ]] \
+                || { die "starter asset is not empty"; return 1; }
+            printf 'starter\n'
+            ;;
+        *) die "asset has invalid state: $state"; return 1 ;;
+    esac
+}
+
+verify_file_against_asset() {
+    local asset=$1 path=$2 state expected_size actual_size expected_digest actual_digest
+    state="$(jq -r '.state' <<<"$asset")" || return 1
+    expected_size="$(jq -r '.size' <<<"$asset")" || return 1
+    actual_size="$(file_size "$path")" || return 1
+    expected_digest="$(jq -r '.digest' <<<"$asset")" || return 1
+    actual_digest="$(sha256_file "$path")" || return 1
+    [[ "$state" == "uploaded" ]] \
+        || { die "asset is not uploaded"; return 1; }
+    [[ "$expected_size" == "$actual_size" ]] \
+        || { die "asset size does not match downloaded bytes"; return 1; }
+    [[ "$expected_digest" == "$actual_digest" ]] \
+        || { die "asset digest does not match downloaded bytes"; return 1; }
+}
+
+redownload_named_asset() {
+    local name=$1 destination=$2 assets asset asset_id
+    local state
+    assets="$(list_assets)" || return 1
+    asset="$(slot_json "$assets" "$name")" || return 1
+    state="$(slot_state "$asset")" || return 1
+    [[ "$state" == "uploaded" ]] \
+        || { die "required uploaded asset is missing: $name"; return 1; }
+    asset_id="$(jq -r '.id' <<<"$asset")" || return 1
+    github_download_asset "$asset_id" "$destination" || return 1
+    verify_file_against_asset "$asset" "$destination" || return 1
+    printf '%s\n' "$asset"
+}
+
+recover_exact_starter() {
+    local name=$1 expected_id=$2 expected_release_id=$3 assets asset state probe after
+    [[ "$ORIGIN_AUTHORITY_VERIFIED" == true ]] \
+        || { die "starter recovery lacks originating authority"; return 1; }
+    [[ "$RELEASE_ID" == "$expected_release_id" ]] \
+        || { die "starter recovery release identity changed"; return 1; }
+    assets="$(list_assets)" || return 1
+    asset="$(slot_json "$assets" "$name")" || return 1
+    state="$(slot_state "$asset")" || return 1
+    [[ "$state" == "starter" ]] \
+        || { die "starter recovery target is not an empty starter"; return 1; }
+    [[ "$(jq -r '.id' <<<"$asset")" == "$expected_id" ]] \
+        || { die "starter identity changed"; return 1; }
+
+    github_delete_asset "$expected_id" || true
+    if probe="$(github_get_asset_by_id_optional "$expected_id")"; then
+        die "starter asset still exists after deletion"
+        return 1
+    elif (($? != 4)); then
+        die "unable to confirm starter deletion by ID"
+        return 1
+    fi
+    after="$(list_assets)" || return 1
+    [[ "$(jq --arg name "$name" --argjson id "$expected_id" \
+        '[.[] | select(.name == $name or .id == $id)] | length' <<<"$after")" == "0" ]] \
+        || { die "starter deletion was not confirmed by release listing"; return 1; }
+}
+
+ensure_uploaded_asset() {
+    local name=$1 source=$2 content_type=$3 destination=$4
+    local transition assets asset state asset_id upload_attempts=0 upload_status
+    local failed_assets failed_asset failed_state attempted_release_id
+    for transition in 1 2 3 4 5 6 7 8; do
+        assets="$(list_assets)" || return 1
+        asset="$(slot_json "$assets" "$name")" || return 1
+        state="$(slot_state "$asset")" || return 1
+        case "$state" in
+            absent)
+                ((upload_attempts += 1))
+                ((upload_attempts <= 3)) \
+                    || { die "upload retry limit reached: $name"; return 1; }
+                attempted_release_id="$RELEASE_ID"
+                upload_status=0
+                github_upload_asset "$RELEASE_ID" "$name" "$source" "$content_type" \
+                    >/dev/null || upload_status=$?
+                if ((upload_status != 0)); then
+                    # Only an empty starter observed immediately after this
+                    # invocation's ambiguous upload belongs to this step.
+                    failed_assets="$(list_assets)" || return 1
+                    failed_asset="$(slot_json "$failed_assets" "$name")" || return 1
+                    failed_state="$(slot_state "$failed_asset")" || return 1
+                    if [[ "$failed_state" == "starter" ]]; then
+                        asset_id="$(jq -r '.id' <<<"$failed_asset")" || return 1
+                        recover_exact_starter "$name" "$asset_id" "$attempted_release_id" \
+                            || return 1
+                    fi
+                fi
+                ;;
+            starter)
+                die "starter asset was not created by this invocation's current upload attempt: $name"
+                return 1
+                ;;
+            uploaded)
+                asset_id="$(jq -r '.id' <<<"$asset")" || return 1
+                github_download_asset "$asset_id" "$destination" || return 1
+                verify_file_against_asset "$asset" "$destination" || return 1
+                cmp -s "$source" "$destination" \
+                    || { die "uploaded asset bytes conflict: $name"; return 1; }
+                printf '%s\n' "$asset"
+                return 0
+                ;;
+        esac
+    done
+    die "unable to establish exact uploaded asset: $name"
+}
+
+validate_pair() {
+    python3 /investment_data/qlib/validate_archive.py \
+        --archive "$1" --manifest "$2" --expected-tag "$3" --require-publishable >/dev/null
+}
+
+select_normal_dolt_commit() {
+    local dolt_dir=/dolt checkout=/dolt/investment_data commit status_output
+    mkdir -p "$dolt_dir" \
+        || { die "cannot create shared Dolt directory"; return 1; }
+    exec 8>"${dolt_dir}/.investment-data.lock" \
+        || { die "cannot open shared Dolt checkout lock"; return 1; }
+    flock -n 8 \
+        || { die "shared Dolt checkout lock is held"; return 1; }
+    if [[ ! -d "$checkout/.dolt" ]]; then
+        printf 'Cloning shared Dolt checkout.\n' >&2
+        (cd "$dolt_dir" && dolt clone chenditc/investment_data) >&2 \
+            || { die "failed to clone shared Dolt checkout"; return 1; }
+    fi
+    status_output="$(cd "$checkout" && dolt status)" \
+        || { die "failed to inspect shared Dolt checkout"; return 1; }
+    grep -q 'nothing to commit, working tree clean' <<<"$status_output" \
+        || { die "shared Dolt checkout is not clean"; return 1; }
+    printf 'Fetching shared Dolt origin/master.\n' >&2
+    (cd "$checkout" && dolt fetch --silent origin master) >&2 \
+        || { die "failed to fetch shared Dolt origin/master"; return 1; }
+    commit="$(cd "$checkout" \
+        && dolt sql -r csv -q "SELECT DOLT_HASHOF('origin/master') AS value" \
+        | tail -n 1 | tr -d '\r')" \
+        || { die "failed to query the fetched Dolt commit"; return 1; }
+    flock -u 8 \
+        || { die "failed to release shared Dolt checkout lock"; return 1; }
+    exec 8>&- \
+        || { die "failed to close shared Dolt checkout lock"; return 1; }
+    [[ "$commit" =~ ^[0-9a-v]{32}$ ]] \
+        || { die "unable to select Dolt commit"; return 1; }
+    printf '%s\n' "$commit"
+}
+
+build_pair() {
+    local tag=$1 dolt_commit=$2 output_dir=$3
+    env -u TRACE -u DUMP_QLIB_MAX_WORKERS -u OUTPUT_DIR \
+        OUTPUT_DIR="$output_dir" \
+        BUILD_RELEASE_TAG="$tag" \
+        BUILD_INVESTMENT_DATA_COMMIT="$GITHUB_SHA" \
+        BUILD_QLIB_COMMIT="$QLIB_COMMIT" \
+        BUILD_IMAGE_DIGEST="$PUBLICATION_IMAGE_DIGEST" \
+        BUILD_DOLT_COMMIT="$dolt_commit" \
+        bash /investment_data/dump_qlib_bin.sh || return 1
+    validate_pair "$output_dir/$ARCHIVE_NAME" "$output_dir/$MANIFEST_NAME" "$tag" \
+        || return 1
+}
+
+preflight() {
+    local operation=$1 variable baked_repository baked_qlib
+    for variable in QLIB_BUILD_ID QLIB_BUILD_ROOT CLEAN_QLIB_BUILD_ROOT CHECK_FRESHNESS REPO DATE UPLOAD_RELEASE_LOCK_FILE; do
+        if [[ -v "$variable" ]]; then
+            die "$variable is not a supported publisher input"
+            return 1
+        fi
+    done
+    [[ "${GITHUB_ACTIONS:-}" == "true" ]] \
+        || { die "publisher requires GitHub Actions authority"; return 1; }
+    [[ "${GITHUB_REPOSITORY:-}" == "$REPOSITORY" ]] \
+        || { die "unexpected GitHub repository"; return 1; }
+    [[ "${GITHUB_REF:-}" == "refs/heads/main" ]] \
+        || { die "publisher requires main branch authority"; return 1; }
+    [[ "${GITHUB_SHA:-}" =~ ^[0-9a-f]{40}$ ]] \
+        || { die "invalid GitHub commit authority"; return 1; }
+    [[ "${GITHUB_RUN_ID:-}" =~ ^[1-9][0-9]*$ ]] \
+        || { die "invalid GitHub run ID"; return 1; }
+    [[ "${GITHUB_RUN_ATTEMPT:-}" =~ ^[1-9][0-9]*$ ]] \
+        || { die "invalid GitHub run attempt"; return 1; }
+    [[ "${PUBLICATION_IMAGE_DIGEST:-}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+        || { die "invalid image digest authority"; return 1; }
+    [[ "${PUBLICATION_BAKED_REPOSITORY_REVISION:-}" == "$GITHUB_SHA" ]] \
+        || { die "launcher repository revision mismatch"; return 1; }
+    [[ "${PUBLICATION_BAKED_QLIB_REVISION:-}" == "$QLIB_COMMIT" ]] \
+        || { die "launcher qlib revision mismatch"; return 1; }
+    if [[ "$operation" == "repair-2026-07-20" ]]; then
+        [[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]] \
+            || { die "repair requires workflow_dispatch"; return 1; }
+    else
+        [[ "${GITHUB_EVENT_NAME:-}" == "schedule" || "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]] \
+            || { die "publish requires schedule or workflow_dispatch"; return 1; }
+    fi
+
+    [[ -n "${GITHUB_TOKEN:-}" ]] || { die "GITHUB_TOKEN is required"; return 1; }
+    for variable in curl jq python3 sha256sum stat flock dolt git cmp mktemp; do
+        require_command "$variable" || return 1
+    done
+    [[ -r "$REPOSITORY_REVISION_FILE" && -r "$QLIB_REVISION_FILE" ]] \
+        || { die "baked revision files are unavailable"; return 1; }
+    baked_repository="$(<"$REPOSITORY_REVISION_FILE")" || return 1
+    baked_qlib="$(<"$QLIB_REVISION_FILE")" || return 1
+    [[ "$baked_repository" == "$GITHUB_SHA" \
+        && "$baked_repository" == "$PUBLICATION_BAKED_REPOSITORY_REVISION" ]] \
+        || { die "baked repository revision mismatch"; return 1; }
+    [[ "$baked_qlib" == "$QLIB_COMMIT" \
+        && "$baked_qlib" == "$PUBLICATION_BAKED_QLIB_REVISION" ]] \
+        || { die "baked qlib revision mismatch"; return 1; }
+
+    exec 9>"$PUBLISHER_LOCK" \
+        || { die "cannot open publisher lock"; return 1; }
+    flock -n 9 || { die "publisher lock is held by another process"; return 1; }
+    ORIGIN_AUTHORITY_VERIFIED=true
+}
+
+get_or_create_release() {
+    local tag=$1 release
+    if release="$(github_get_release_by_tag_optional "$tag")"; then
+        :
+    elif (($? == 4)); then
+        release="$(github_create_release "$tag")" || return 1
+    else
+        die "unable to resolve release $tag"
+        return 1
+    fi
+    jq -e --arg tag "$tag" '
+        (.id | type) == "number"
+        and .id > 0
+        and .tag_name == $tag
+        and .draft == false
+        and .prerelease == false
+    ' >/dev/null 2>&1 <<<"$release" \
+        || { die "release identity, draft, or prerelease state is invalid"; return 1; }
+    RELEASE_ID="$(jq -r '.id' <<<"$release")" || return 1
+}
+
+publish_current() {
+    local tag dolt_commit build_dir archive manifest assets archive_slot manifest_slot
+    local archive_state manifest_state downloaded_archive downloaded_manifest
+    tag="$(TZ=Asia/Shanghai date +%F)" || return 1
+    dolt_commit="$(select_normal_dolt_commit)" || return 1
+    build_dir="$WORK_DIR/build"
+    mkdir -p "$build_dir" || return 1
+    build_pair "$tag" "$dolt_commit" "$build_dir" || return 1
+    archive="$build_dir/$ARCHIVE_NAME"
+    manifest="$build_dir/$MANIFEST_NAME"
+
+    get_or_create_release "$tag" || return 1
+    assets="$(list_assets)" || return 1
+    archive_slot="$(slot_json "$assets" "$ARCHIVE_NAME")" || return 1
+    manifest_slot="$(slot_json "$assets" "$MANIFEST_NAME")" || return 1
+    archive_state="$(slot_state "$archive_slot")" || return 1
+    manifest_state="$(slot_state "$manifest_slot")" || return 1
+    if [[ "$archive_state" == "absent" ]]; then
+        [[ "$manifest_state" == "absent" ]] \
+            || { die "manifest exists before canonical archive"; return 1; }
+    elif [[ "$archive_state" == "uploaded" ]]; then
+        [[ "$manifest_state" == "absent" || "$manifest_state" == "uploaded" ]] \
+            || { die "invalid canonical manifest state"; return 1; }
+    else
+        die "pre-existing canonical starter conflicts with current-attempt ownership"
+        return 1
+    fi
+
+    downloaded_archive="$WORK_DIR/published-archive"
+    downloaded_manifest="$WORK_DIR/published-manifest"
+    ensure_uploaded_asset "$ARCHIVE_NAME" "$archive" application/gzip "$downloaded_archive" \
+        >/dev/null || return 1
+    ensure_uploaded_asset "$MANIFEST_NAME" "$manifest" application/json "$downloaded_manifest" \
+        >/dev/null || return 1
+    redownload_named_asset "$ARCHIVE_NAME" "$downloaded_archive" >/dev/null || return 1
+    redownload_named_asset "$MANIFEST_NAME" "$downloaded_manifest" >/dev/null || return 1
+    cmp -s "$archive" "$downloaded_archive" \
+        || { die "canonical archive differs from local build"; return 1; }
+    cmp -s "$manifest" "$downloaded_manifest" \
+        || { die "canonical manifest differs from local build"; return 1; }
+    validate_pair "$downloaded_archive" "$downloaded_manifest" "$tag" || return 1
+    printf 'Validated release %s with immutable archive and manifest assets.\n' "$tag"
+}
+
+require_original_identity() {
+    local asset=$1
+    [[ "$(jq -r '.id' <<<"$asset")" == "$FIXED_ORIGINAL_ASSET_ID" \
+        && "$(jq -r '.name' <<<"$asset")" == "$ARCHIVE_NAME" \
+        && "$(jq -r '.state' <<<"$asset")" == "uploaded" \
+        && "$(jq -r '.size' <<<"$asset")" == "$FIXED_ORIGINAL_SIZE" \
+        && "$(jq -r '.digest' <<<"$asset")" == "$FIXED_ORIGINAL_DIGEST" \
+        && "$(jq -r '.created_at' <<<"$asset")" == "$FIXED_ORIGINAL_CREATED_AT" \
+        && "$(jq -r '.updated_at' <<<"$asset")" == "$FIXED_ORIGINAL_UPDATED_AT" ]] \
+        || { die "original 2026-07-20 asset identity changed"; return 1; }
+}
+
+create_receipt() {
+    local manifest_path=$1 output_path=$2 backup_json=$3 candidate_archive_json=$4 candidate_manifest_json=$5
+    local canonical_archive_size canonical_archive_digest canonical_manifest_size canonical_manifest_digest
+    canonical_archive_size="$(file_size "$CANDIDATE_ARCHIVE_LOCAL")" || return 1
+    canonical_archive_digest="$(sha256_file "$CANDIDATE_ARCHIVE_LOCAL")" || return 1
+    canonical_manifest_size="$(file_size "$CANDIDATE_MANIFEST_LOCAL")" || return 1
+    canonical_manifest_digest="$(sha256_file "$CANDIDATE_MANIFEST_LOCAL")" || return 1
+    python3 - "$manifest_path" "$output_path" "$backup_json" "$candidate_archive_json" \
+        "$candidate_manifest_json" "$canonical_archive_size" "$canonical_archive_digest" \
+        "$canonical_manifest_size" "$canonical_manifest_digest" \
+        "$FIXED_ORIGINAL_SIZE" "$FIXED_ORIGINAL_DIGEST" \
+        "$FIXED_ORIGINAL_CREATED_AT" "$FIXED_ORIGINAL_UPDATED_AT" <<'PY'
+import json
+import sys
+
+manifest_path, output_path = sys.argv[1:3]
+backup, candidate_archive, candidate_manifest = map(json.loads, sys.argv[3:6])
+
+def record(asset):
+    return {
+        "asset_id": asset["id"],
+        "name": asset["name"],
+        "state": asset["state"],
+        "size_bytes": asset["size"],
+        "sha256": asset["digest"],
+        "created_at": asset["created_at"],
+        "updated_at": asset["updated_at"],
+    }
+
+with open(manifest_path, encoding="utf-8") as stream:
+    manifest = json.load(stream)
+
+receipt = {
+    "operation": "repair-2026-07-20",
+    "release_tag": "2026-07-20",
+    "release_id": 356733573,
+    "authority": {
+        "investment_data_commit": manifest["investment_data_commit"],
+        "qlib_commit": manifest["qlib_commit"],
+        "dolt_commit": manifest["dolt_commit"],
+        "image_digest": manifest["image_digest"],
+    },
+    "manifest": manifest,
+    "assets": {
+        "original": {
+            "asset_id": 483488955,
+            "name": "qlib_bin.tar.gz",
+            "state": "uploaded",
+            "size_bytes": int(sys.argv[10]),
+            "sha256": sys.argv[11],
+            "created_at": sys.argv[12],
+            "updated_at": sys.argv[13],
+        },
+        "backup": record(backup),
+        "candidate_archive": record(candidate_archive),
+        "candidate_manifest": record(candidate_manifest),
+        "canonical_archive": {
+            "asset_id": None,
+            "name": "qlib_bin.tar.gz",
+            "state": "uploaded",
+            "size_bytes": int(sys.argv[6]),
+            "sha256": sys.argv[7],
+            "created_at": None,
+            "updated_at": None,
+        },
+        "canonical_manifest": {
+            "asset_id": None,
+            "name": "qlib_bin.manifest.json",
+            "state": "uploaded",
+            "size_bytes": int(sys.argv[8]),
+            "sha256": sys.argv[9],
+            "created_at": None,
+            "updated_at": None,
+        },
+    },
+}
+with open(output_path, "w", encoding="utf-8", newline="\n") as stream:
+    json.dump(receipt, stream, separators=(",", ":"))
+    stream.write("\n")
+PY
+    return $?
+}
+
+validate_repair_receipt() {
+    local phase=$1 receipt_path=$2 manifest_path=$3 original_json=$4 backup_json=$5
+    local candidate_archive_json=$6 candidate_manifest_json=$7 canonical_archive_json=$8
+    local canonical_manifest_json=$9
+    shift 9
+    local backup_path=$1 candidate_archive_path=$2 candidate_manifest_path=$3
+    local canonical_archive_path=$4 canonical_manifest_path=$5
+    python3 - "$phase" "$receipt_path" "$manifest_path" \
+        "$original_json" "$backup_json" "$candidate_archive_json" \
+        "$candidate_manifest_json" "$canonical_archive_json" "$canonical_manifest_json" \
+        "$backup_path" "$candidate_archive_path" "$candidate_manifest_path" \
+        "$canonical_archive_path" "$canonical_manifest_path" \
+        "$CANDIDATE_ARCHIVE_NAME" "$CANDIDATE_MANIFEST_NAME" \
+        "$FIXED_ORIGINAL_SIZE" "$FIXED_ORIGINAL_DIGEST" \
+        "$FIXED_ORIGINAL_CREATED_AT" "$FIXED_ORIGINAL_UPDATED_AT" <<'PY'
+import datetime
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+(
+    phase,
+    receipt_path,
+    manifest_path,
+    original_json,
+    backup_json,
+    candidate_archive_json,
+    candidate_manifest_json,
+    canonical_archive_json,
+    canonical_manifest_json,
+    backup_path,
+    candidate_archive_path,
+    candidate_manifest_path,
+    canonical_archive_path,
+    canonical_manifest_path,
+    candidate_archive_name,
+    candidate_manifest_name,
+    fixed_original_size,
+    fixed_original_digest,
+    fixed_original_created_at,
+    fixed_original_updated_at,
+) = sys.argv[1:]
+
+TOP_KEYS = ["operation", "release_tag", "release_id", "authority", "manifest", "assets"]
+AUTHORITY_KEYS = ["investment_data_commit", "qlib_commit", "dolt_commit", "image_digest"]
+MANIFEST_KEYS = [
+    "release_tag",
+    "target_trade_date",
+    "future_start_date",
+    "future_end_date",
+    "dolt_commit",
+    "investment_data_commit",
+    "qlib_commit",
+    "image_digest",
+    "archive_size_bytes",
+    "archive_sha256",
+]
+ASSET_KEYS = [
+    "original",
+    "backup",
+    "candidate_archive",
+    "candidate_manifest",
+    "canonical_archive",
+    "canonical_manifest",
+]
+RECORD_KEYS = [
+    "asset_id",
+    "name",
+    "state",
+    "size_bytes",
+    "sha256",
+    "created_at",
+    "updated_at",
+]
+DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
+DATE_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}\Z")
+GIT_RE = re.compile(r"[0-9a-f]{40}\Z")
+DOLT_RE = re.compile(r"[0-9a-v]{32}\Z")
+RFC3339_RE = re.compile(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"
+    r"(?:\.[0-9]+)?(?:Z|[+-][0-9]{2}:[0-9]{2})\Z"
+)
+
+
+def reject(message):
+    raise ValueError(message)
+
+
+def no_duplicates(pairs):
+    keys = [key for key, _ in pairs]
+    if len(keys) != len(set(keys)):
+        reject("duplicate JSON key")
+    return dict(pairs)
+
+
+def load_exact(path):
+    try:
+        return json.loads(Path(path).read_bytes().decode("utf-8"), object_pairs_hook=no_duplicates)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("invalid receipt or manifest JSON") from exc
+
+
+def positive_integer(value):
+    return type(value) is int and value > 0
+
+
+def canonical_digest(value):
+    return isinstance(value, str) and DIGEST_RE.fullmatch(value) is not None
+
+
+def rfc3339(value):
+    if not isinstance(value, str) or RFC3339_RE.fullmatch(value) is None:
+        return False
+    try:
+        parsed = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return parsed.tzinfo is not None
+
+
+def file_identity(path):
+    data = Path(path).read_bytes()
+    return len(data), "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def load_live(raw, label):
+    if raw == "null":
+        return None
+    try:
+        asset = json.loads(raw, object_pairs_hook=no_duplicates)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{label} live asset JSON is invalid") from exc
+    required = ("id", "name", "state", "size", "digest", "created_at", "updated_at")
+    if not isinstance(asset, dict) or any(key not in asset for key in required):
+        reject(f"{label} live asset fields are incomplete")
+    if not positive_integer(asset["id"]):
+        reject(f"{label} live asset ID is invalid")
+    if not isinstance(asset["name"], str) or asset["state"] != "uploaded":
+        reject(f"{label} live asset name/state is invalid")
+    if not positive_integer(asset["size"]) or not canonical_digest(asset["digest"]):
+        reject(f"{label} live asset size/digest is invalid")
+    if not rfc3339(asset["created_at"]) or not rfc3339(asset["updated_at"]):
+        reject(f"{label} live asset timestamp is invalid")
+    return asset
+
+
+receipt = load_exact(receipt_path)
+manifest = load_exact(manifest_path)
+if not isinstance(receipt, dict) or list(receipt) != TOP_KEYS:
+    reject("receipt top-level schema is invalid")
+if (
+    not isinstance(manifest, dict)
+    or list(manifest) != MANIFEST_KEYS
+    or not isinstance(receipt["manifest"], dict)
+    or list(receipt["manifest"]) != MANIFEST_KEYS
+    or receipt["manifest"] != manifest
+):
+    reject("receipt manifest is not the exact downloaded manifest")
+if any(
+    not isinstance(manifest[key], str) or DATE_RE.fullmatch(manifest[key]) is None
+    for key in MANIFEST_KEYS[:4]
+):
+    reject("receipt manifest date form is invalid")
+try:
+    if any(
+        datetime.date.fromisoformat(manifest[key]).isoformat() != manifest[key]
+        for key in MANIFEST_KEYS[:4]
+    ):
+        reject("receipt manifest date value is invalid")
+except ValueError as exc:
+    raise ValueError("receipt manifest date value is invalid") from exc
+if (
+    DOLT_RE.fullmatch(manifest["dolt_commit"]) is None
+    or GIT_RE.fullmatch(manifest["investment_data_commit"]) is None
+    or manifest["qlib_commit"] != "b87a2c294d364a33fb739359886acffe8ec907d1"
+    or not canonical_digest(manifest["image_digest"])
+    or not positive_integer(manifest["archive_size_bytes"])
+    or not canonical_digest(manifest["archive_sha256"])
+):
+    reject("receipt manifest value/type is invalid")
+if receipt["operation"] != "repair-2026-07-20" or receipt["release_tag"] != "2026-07-20":
+    reject("receipt operation/tag is invalid")
+if type(receipt["release_id"]) is not int or receipt["release_id"] != 356733573:
+    reject("receipt release ID is invalid")
+
+authority = receipt["authority"]
+if not isinstance(authority, dict) or list(authority) != AUTHORITY_KEYS:
+    reject("receipt authority schema is invalid")
+if authority != {
+    "investment_data_commit": manifest["investment_data_commit"],
+    "qlib_commit": manifest["qlib_commit"],
+    "dolt_commit": manifest["dolt_commit"],
+    "image_digest": manifest["image_digest"],
+}:
+    reject("receipt authority differs from manifest")
+
+assets = receipt["assets"]
+if not isinstance(assets, dict) or list(assets) != ASSET_KEYS:
+    reject("receipt must contain the authoritative six asset records")
+expected_names = {
+    "original": "qlib_bin.tar.gz",
+    "backup": "qlib_bin.original-2026-07-20-483488955.tar.gz",
+    "candidate_archive": candidate_archive_name,
+    "candidate_manifest": candidate_manifest_name,
+    "canonical_archive": "qlib_bin.tar.gz",
+    "canonical_manifest": "qlib_bin.manifest.json",
+}
+for label, record in assets.items():
+    if not isinstance(record, dict) or list(record) != RECORD_KEYS:
+        reject(f"{label} receipt record schema is invalid")
+    nullable = label in ("canonical_archive", "canonical_manifest")
+    if nullable:
+        if record["asset_id"] is not None or record["created_at"] is not None or record["updated_at"] is not None:
+            reject(f"{label} planned identity fields must be null")
+    else:
+        if not positive_integer(record["asset_id"]):
+            reject(f"{label} receipt asset ID is invalid")
+        if not rfc3339(record["created_at"]) or not rfc3339(record["updated_at"]):
+            reject(f"{label} receipt timestamp is invalid")
+    if record["name"] != expected_names[label] or record["state"] != "uploaded":
+        reject(f"{label} receipt name/state is invalid")
+    if not positive_integer(record["size_bytes"]) or not canonical_digest(record["sha256"]):
+        reject(f"{label} receipt size/digest is invalid")
+
+original = assets["original"]
+if original != {
+    "asset_id": 483488955,
+    "name": "qlib_bin.tar.gz",
+    "state": "uploaded",
+    "size_bytes": int(fixed_original_size),
+    "sha256": fixed_original_digest,
+    "created_at": fixed_original_created_at,
+    "updated_at": fixed_original_updated_at,
+}:
+    reject("receipt original record differs from captured authority")
+
+if assets["backup"]["size_bytes"] != original["size_bytes"] or assets["backup"]["sha256"] != original["sha256"]:
+    reject("receipt backup does not preserve the original identity")
+if (
+    assets["candidate_archive"]["size_bytes"] != manifest["archive_size_bytes"]
+    or assets["candidate_archive"]["sha256"] != manifest["archive_sha256"]
+):
+    reject("receipt candidate archive differs from manifest")
+if any(
+    assets[canonical][field] != assets[candidate][field]
+    for canonical, candidate in (
+        ("canonical_archive", "candidate_archive"),
+        ("canonical_manifest", "candidate_manifest"),
+    )
+    for field in ("size_bytes", "sha256")
+):
+    reject("receipt planned canonical pair differs from candidate pair")
+
+for label, path in (
+    ("backup", backup_path),
+    ("candidate_archive", candidate_archive_path),
+    ("candidate_manifest", candidate_manifest_path),
+    ("canonical_archive", canonical_archive_path),
+    ("canonical_manifest", canonical_manifest_path),
+):
+    if path != "-" and file_identity(path) != (
+        assets[label]["size_bytes"],
+        assets[label]["sha256"],
+    ):
+        reject(f"{label} downloaded bytes differ from receipt")
+
+live_assets = {
+    "original": load_live(original_json, "original"),
+    "backup": load_live(backup_json, "backup"),
+    "candidate_archive": load_live(candidate_archive_json, "candidate_archive"),
+    "candidate_manifest": load_live(candidate_manifest_json, "candidate_manifest"),
+    "canonical_archive": load_live(canonical_archive_json, "canonical_archive"),
+    "canonical_manifest": load_live(canonical_manifest_json, "canonical_manifest"),
+}
+if phase == "pre-delete":
+    if live_assets["original"] is None or live_assets["canonical_archive"] is not None or live_assets["canonical_manifest"] is not None:
+        reject("pre-delete live asset set is invalid")
+elif phase == "post-delete":
+    if live_assets["original"] is not None:
+        reject("post-delete original is unexpectedly present")
+elif phase == "accepted":
+    if live_assets["original"] is not None or live_assets["canonical_archive"] is None or live_assets["canonical_manifest"] is None:
+        reject("accepted live asset set is invalid")
+else:
+    reject("unknown fixed repair receipt phase")
+
+for required in ("backup", "candidate_archive", "candidate_manifest"):
+    if live_assets[required] is None:
+        reject(f"required live asset is absent: {required}")
+for label, live in live_assets.items():
+    if live is None:
+        continue
+    mapped = {
+        "asset_id": live["id"],
+        "name": live["name"],
+        "state": live["state"],
+        "size_bytes": live["size"],
+        "sha256": live["digest"],
+        "created_at": live["created_at"],
+        "updated_at": live["updated_at"],
+    }
+    for field, expected in assets[label].items():
+        if expected is not None and mapped[field] != expected:
+            reject(f"{label} live field differs from receipt: {field}")
+PY
+}
+
+validate_repair_prefix() {
+    local assets=$1 original_present=$2 candidate_archive_state candidate_manifest_state backup_state receipt_state
+    local canonical_archive_state canonical_manifest_state unexpected
+    unexpected="$(jq --arg archive "$CANDIDATE_ARCHIVE_NAME" --arg manifest "$CANDIDATE_MANIFEST_NAME" \
+        '[.[] | select((.name | startswith("qlib_bin.repair-2026-07-20-")) and .name != $archive and .name != $manifest)] | length' <<<"$assets")" \
+        || return 1
+    [[ "$unexpected" == "0" ]] \
+        || { die "candidate authority does not match this workflow commit and image"; return 1; }
+
+    candidate_archive_state="$(slot_state "$(slot_json "$assets" "$CANDIDATE_ARCHIVE_NAME")")" \
+        || return 1
+    candidate_manifest_state="$(slot_state "$(slot_json "$assets" "$CANDIDATE_MANIFEST_NAME")")" \
+        || return 1
+    backup_state="$(slot_state "$(slot_json "$assets" "$BACKUP_NAME")")" || return 1
+    receipt_state="$(slot_state "$(slot_json "$assets" "$RECEIPT_NAME")")" || return 1
+    canonical_manifest_state="$(slot_state "$(slot_json "$assets" "$MANIFEST_NAME")")" \
+        || return 1
+
+    if [[ "$original_present" == true ]]; then
+        [[ "$canonical_manifest_state" == "absent" ]] \
+            || { die "canonical manifest exists before original deletion"; return 1; }
+        if [[ "$candidate_archive_state" == "absent" ]]; then
+            [[ "$candidate_manifest_state/$backup_state/$receipt_state" == "absent/absent/absent" ]] \
+                || { die "repair assets are not a valid preparation prefix"; return 1; }
+        elif [[ "$candidate_archive_state" != "uploaded" ]]; then
+            die "pre-existing candidate archive starter conflicts with current-attempt ownership"
+            return 1
+        elif [[ "$candidate_manifest_state" == "absent" ]]; then
+            [[ "$backup_state/$receipt_state" == "absent/absent" ]] \
+                || { die "repair assets are not a valid preparation prefix"; return 1; }
+        elif [[ "$candidate_manifest_state" != "uploaded" ]]; then
+            die "pre-existing candidate manifest starter conflicts with current-attempt ownership"
+            return 1
+        elif [[ "$backup_state" == "absent" ]]; then
+            [[ "$receipt_state" == "absent" ]] \
+                || { die "receipt exists before verified backup"; return 1; }
+        elif [[ "$backup_state" != "uploaded" ]]; then
+            die "pre-existing backup starter conflicts with current-attempt ownership"
+            return 1
+        elif [[ "$receipt_state" != "absent" && "$receipt_state" != "uploaded" ]]; then
+            die "pre-existing receipt starter conflicts with current-attempt ownership"
+            return 1
+        fi
+    else
+        [[ "$candidate_archive_state/$candidate_manifest_state/$backup_state/$receipt_state" == \
+            "uploaded/uploaded/uploaded/uploaded" ]] \
+            || { die "original is absent without complete prepared evidence"; return 1; }
+        canonical_archive_state="$(slot_state "$(slot_json "$assets" "$ARCHIVE_NAME")")" \
+            || return 1
+        if [[ "$canonical_archive_state" == "absent" ]]; then
+            [[ "$canonical_manifest_state" == "absent" ]] \
+                || { die "canonical manifest exists before canonical archive"; return 1; }
+        elif [[ "$canonical_archive_state" != "uploaded" ]]; then
+            die "pre-existing canonical archive starter conflicts with current-attempt ownership"
+            return 1
+        elif [[ "$canonical_manifest_state" != "absent" && "$canonical_manifest_state" != "uploaded" ]]; then
+            die "pre-existing canonical manifest starter conflicts with current-attempt ownership"
+            return 1
+        fi
+    fi
+}
+
+verify_fixed_release() {
+    local release
+    release="$(github_api_get "/releases/${FIXED_RELEASE_ID}")" || return 1
+    jq -e --arg tag "$FIXED_TAG" --argjson id "$FIXED_RELEASE_ID" '
+        .id == $id
+        and .tag_name == $tag
+        and .draft == false
+        and .prerelease == false
+    ' >/dev/null 2>&1 <<<"$release" \
+        || { die "fixed release identity, draft, or prerelease state is invalid"; return 1; }
+    RELEASE_ID=$FIXED_RELEASE_ID
+}
+
+delete_original_after_gate() {
+    local probe assets
+    github_delete_asset "$FIXED_ORIGINAL_ASSET_ID" || true
+    if probe="$(github_get_asset_by_id_optional "$FIXED_ORIGINAL_ASSET_ID")"; then
+        die "original asset still exists after deletion"
+        return 1
+    elif (($? != 4)); then
+        die "unable to confirm original deletion by ID"
+        return 1
+    fi
+    assets="$(list_assets)" || return 1
+    [[ "$(jq --argjson id "$FIXED_ORIGINAL_ASSET_ID" --arg name "$ARCHIVE_NAME" \
+        '[.[] | select(.id == $id or .name == $name)] | length' <<<"$assets")" == "0" ]] \
+        || { die "original deletion was not confirmed by release listing"; return 1; }
+}
+
+repair_fixed_release() {
+    local build_dir archive manifest archive_digest image_hex candidate_stem
+    local assets original_asset original_by_id original_present original_local backup_local
+    local candidate_archive_json candidate_manifest_json backup_json receipt_json
+    local candidate_archive_download candidate_manifest_download receipt_local receipt_download
+    local canonical_archive_json canonical_manifest_json
+    local canonical_archive_download canonical_manifest_download receipt_phase
+
+    build_dir="$WORK_DIR/build"
+    mkdir -p "$build_dir" || return 1
+    build_pair "$FIXED_TAG" "$FIXED_DOLT_COMMIT" "$build_dir" || return 1
+    archive="$build_dir/$ARCHIVE_NAME"
+    manifest="$build_dir/$MANIFEST_NAME"
+    [[ "$(jq -r '.target_trade_date' "$manifest")" == "2026-07-20" \
+        && "$(jq -r '.future_start_date' "$manifest")" == "2026-07-21" \
+        && "$(jq -r '.future_end_date' "$manifest")" == "2026-12-31" ]] \
+        || { die "fixed repair manifest dates changed"; return 1; }
+    archive_digest="$(sha256_file "$archive")" || return 1
+    image_hex="${PUBLICATION_IMAGE_DIGEST#sha256:}"
+    candidate_stem="qlib_bin.repair-2026-07-20-${GITHUB_SHA}-${image_hex}-${archive_digest#sha256:}"
+    CANDIDATE_ARCHIVE_NAME="${candidate_stem}.tar.gz"
+    CANDIDATE_MANIFEST_NAME="${candidate_stem}.manifest.json"
+    [[ "$CANDIDATE_ARCHIVE_NAME" =~ ^qlib_bin\.repair-2026-07-20-[0-9a-f]{40}-[0-9a-f]{64}-[0-9a-f]{64}\.tar\.gz$ ]] \
+        || return 1
+    [[ "$CANDIDATE_MANIFEST_NAME" =~ ^qlib_bin\.repair-2026-07-20-[0-9a-f]{40}-[0-9a-f]{64}-[0-9a-f]{64}\.manifest\.json$ ]] \
+        || return 1
+
+    verify_fixed_release || return 1
+    assets="$(list_assets)" || return 1
+    original_asset="$(jq -c --argjson id "$FIXED_ORIGINAL_ASSET_ID" \
+        '[.[] | select(.id == $id)] | if length == 0 then null elif length == 1 then .[0] else error("duplicate original ID") end' <<<"$assets")" \
+        || return 1
+    original_present=false
+    if [[ "$original_asset" != "null" ]]; then
+        original_present=true
+        require_original_identity "$original_asset" || return 1
+        if ! original_by_id="$(github_get_asset_by_id_optional "$FIXED_ORIGINAL_ASSET_ID")"; then
+            die "original asset disappeared during exact-ID refetch"
+            return 1
+        fi
+        require_original_identity "$original_by_id" || return 1
+        [[ "$(jq --arg name "$ARCHIVE_NAME" '[.[] | select(.name == $name)] | length' <<<"$assets")" == "1" ]] \
+            || { die "canonical archive name is duplicated while original exists"; return 1; }
+    fi
+    validate_repair_prefix "$assets" "$original_present" || return 1
+
+    original_local="$WORK_DIR/original-archive"
+    backup_local="$WORK_DIR/backup-archive"
+    if [[ "$original_present" == true ]]; then
+        github_download_asset "$FIXED_ORIGINAL_ASSET_ID" "$original_local" || return 1
+        verify_file_against_asset "$original_asset" "$original_local" || return 1
+        [[ "$(sha256_file "$original_local")" == "$FIXED_ORIGINAL_DIGEST" ]] \
+            || { die "original downloaded bytes changed"; return 1; }
+    else
+        backup_json="$(redownload_named_asset "$BACKUP_NAME" "$backup_local")" || return 1
+        [[ "$(file_size "$backup_local")" == "$FIXED_ORIGINAL_SIZE" \
+            && "$(sha256_file "$backup_local")" == "$FIXED_ORIGINAL_DIGEST" ]] \
+            || { die "backup does not preserve original bytes"; return 1; }
+        cp "$backup_local" "$original_local" || return 1
+    fi
+
+    candidate_archive_download="$WORK_DIR/candidate-archive"
+    candidate_manifest_download="$WORK_DIR/candidate-manifest"
+    candidate_archive_json="$(ensure_uploaded_asset "$CANDIDATE_ARCHIVE_NAME" "$archive" application/gzip "$candidate_archive_download")" \
+        || return 1
+    candidate_manifest_json="$(ensure_uploaded_asset "$CANDIDATE_MANIFEST_NAME" "$manifest" application/json "$candidate_manifest_download")" \
+        || return 1
+    candidate_archive_json="$(redownload_named_asset "$CANDIDATE_ARCHIVE_NAME" "$candidate_archive_download")" \
+        || return 1
+    candidate_manifest_json="$(redownload_named_asset "$CANDIDATE_MANIFEST_NAME" "$candidate_manifest_download")" \
+        || return 1
+    cmp -s "$archive" "$candidate_archive_download" \
+        || { die "candidate archive differs from clean rebuild"; return 1; }
+    cmp -s "$manifest" "$candidate_manifest_download" \
+        || { die "candidate manifest differs from clean rebuild"; return 1; }
+    validate_pair "$candidate_archive_download" "$candidate_manifest_download" "$FIXED_TAG" \
+        || return 1
+    CANDIDATE_ARCHIVE_LOCAL="$candidate_archive_download"
+    CANDIDATE_MANIFEST_LOCAL="$candidate_manifest_download"
+
+    backup_json="$(ensure_uploaded_asset "$BACKUP_NAME" "$original_local" application/gzip "$backup_local")" \
+        || return 1
+    backup_json="$(redownload_named_asset "$BACKUP_NAME" "$backup_local")" || return 1
+    cmp -s "$original_local" "$backup_local" \
+        || { die "backup bytes differ from original"; return 1; }
+
+    receipt_local="$WORK_DIR/repair-receipt"
+    receipt_download="$WORK_DIR/downloaded-receipt"
+    create_receipt "$candidate_manifest_download" "$receipt_local" "$backup_json" \
+        "$candidate_archive_json" "$candidate_manifest_json" || return 1
+    if [[ "$original_present" == true ]]; then
+        receipt_phase=pre-delete
+        original_by_id="$(github_get_asset_by_id_optional "$FIXED_ORIGINAL_ASSET_ID")" \
+            || return 1
+        require_original_identity "$original_by_id" || return 1
+    else
+        receipt_phase=post-delete
+        original_by_id=null
+    fi
+    validate_repair_receipt "$receipt_phase" "$receipt_local" "$candidate_manifest_download" \
+        "$original_by_id" "$backup_json" "$candidate_archive_json" "$candidate_manifest_json" \
+        null null "$backup_local" "$candidate_archive_download" "$candidate_manifest_download" \
+        - - || { die "locally created repair receipt is invalid"; return 1; }
+    receipt_json="$(ensure_uploaded_asset "$RECEIPT_NAME" "$receipt_local" application/json "$receipt_download")" \
+        || return 1
+    receipt_json="$(redownload_named_asset "$RECEIPT_NAME" "$receipt_download")" || return 1
+    cmp -s "$receipt_local" "$receipt_download" \
+        || { die "repair receipt bytes conflict"; return 1; }
+
+    # The preparation evidence has now been redownloaded and cross-checked.
+    if [[ "$original_present" == true ]]; then
+        candidate_archive_json="$(redownload_named_asset "$CANDIDATE_ARCHIVE_NAME" "$candidate_archive_download")" \
+            || return 1
+        candidate_manifest_json="$(redownload_named_asset "$CANDIDATE_MANIFEST_NAME" "$candidate_manifest_download")" \
+            || return 1
+        backup_json="$(redownload_named_asset "$BACKUP_NAME" "$backup_local")" || return 1
+        receipt_json="$(redownload_named_asset "$RECEIPT_NAME" "$receipt_download")" || return 1
+        cmp -s "$archive" "$candidate_archive_download" \
+            || { die "candidate archive changed before deletion gate"; return 1; }
+        cmp -s "$manifest" "$candidate_manifest_download" \
+            || { die "candidate manifest changed before deletion gate"; return 1; }
+        cmp -s "$original_local" "$backup_local" \
+            || { die "backup changed before deletion gate"; return 1; }
+        cmp -s "$receipt_local" "$receipt_download" \
+            || { die "receipt changed before deletion gate"; return 1; }
+        validate_pair "$candidate_archive_download" "$candidate_manifest_download" "$FIXED_TAG" \
+            || return 1
+        if ! original_by_id="$(github_get_asset_by_id_optional "$FIXED_ORIGINAL_ASSET_ID")"; then
+            die "original asset disappeared before the deletion gate"
+            return 1
+        fi
+        require_original_identity "$original_by_id" || return 1
+        assets="$(list_assets)" || return 1
+        validate_repair_prefix "$assets" true || return 1
+        original_by_id="$(slot_json "$assets" "$ARCHIVE_NAME")" || return 1
+        require_original_identity "$original_by_id" || return 1
+        validate_repair_receipt pre-delete "$receipt_download" "$candidate_manifest_download" \
+            "$original_by_id" "$backup_json" "$candidate_archive_json" "$candidate_manifest_json" \
+            null null "$backup_local" "$candidate_archive_download" "$candidate_manifest_download" \
+            - - || { die "repair receipt/live deletion gate failed"; return 1; }
+        delete_original_after_gate || return 1
+    fi
+
+    # Re-fetch every prepared asset after the swap boundary.
+    candidate_archive_json="$(redownload_named_asset "$CANDIDATE_ARCHIVE_NAME" "$candidate_archive_download")" \
+        || return 1
+    candidate_manifest_json="$(redownload_named_asset "$CANDIDATE_MANIFEST_NAME" "$candidate_manifest_download")" \
+        || return 1
+    backup_json="$(redownload_named_asset "$BACKUP_NAME" "$backup_local")" || return 1
+    receipt_json="$(redownload_named_asset "$RECEIPT_NAME" "$receipt_download")" || return 1
+    cmp -s "$receipt_local" "$receipt_download" \
+        || { die "receipt changed before canonical upload"; return 1; }
+    validate_pair "$candidate_archive_download" "$candidate_manifest_download" "$FIXED_TAG" \
+        || return 1
+    validate_repair_receipt post-delete "$receipt_download" "$candidate_manifest_download" \
+        null "$backup_json" "$candidate_archive_json" "$candidate_manifest_json" \
+        null null "$backup_local" "$candidate_archive_download" "$candidate_manifest_download" \
+        - - || { die "repair receipt/live swap gate failed"; return 1; }
+
+    canonical_archive_download="$WORK_DIR/canonical-archive"
+    canonical_manifest_download="$WORK_DIR/canonical-manifest"
+    ensure_uploaded_asset "$ARCHIVE_NAME" "$candidate_archive_download" application/gzip "$canonical_archive_download" \
+        >/dev/null || return 1
+    ensure_uploaded_asset "$MANIFEST_NAME" "$candidate_manifest_download" application/json "$canonical_manifest_download" \
+        >/dev/null || return 1
+    canonical_archive_json="$(redownload_named_asset "$ARCHIVE_NAME" "$canonical_archive_download")" \
+        || return 1
+    canonical_manifest_json="$(redownload_named_asset "$MANIFEST_NAME" "$canonical_manifest_download")" \
+        || return 1
+    cmp -s "$candidate_archive_download" "$canonical_archive_download" \
+        || { die "canonical archive differs from candidate"; return 1; }
+    cmp -s "$candidate_manifest_download" "$canonical_manifest_download" \
+        || { die "canonical manifest differs from candidate"; return 1; }
+    validate_pair "$canonical_archive_download" "$canonical_manifest_download" "$FIXED_TAG" \
+        || return 1
+    validate_repair_receipt accepted "$receipt_download" "$candidate_manifest_download" \
+        null "$backup_json" "$candidate_archive_json" "$candidate_manifest_json" \
+        "$canonical_archive_json" "$canonical_manifest_json" \
+        "$backup_local" "$candidate_archive_download" "$candidate_manifest_download" \
+        "$canonical_archive_download" "$canonical_manifest_download" \
+        || { die "repair receipt/live acceptance gate failed"; return 1; }
+    printf 'Repair %s reached Accepted with backup, candidate pair, and receipt retained.\n' "$FIXED_TAG"
+}
+
+main() {
+    local operation
+    if (($# == 0)); then
+        operation=publish
+    elif (($# == 1)) && [[ "$1" == "repair-2026-07-20" ]]; then
+        operation=$1
+    else
+        usage
+        return 2
+    fi
+
+    preflight "$operation" || return 1
+    WORK_DIR="$(mktemp -d /tmp/investment-data-publisher.XXXXXXXX)" || return 1
+    trap 'status=$?; [[ -z "$WORK_DIR" || ! -d "$WORK_DIR" ]] || rm -rf -- "$WORK_DIR"; exit "$status"' EXIT
+    if [[ "$operation" == "publish" ]]; then
+        publish_current
+    else
+        repair_fixed_release
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
 fi
-if [[ -n "${https_proxy-}" ]]; then
-  git config --global https.proxy "${https_proxy}"
-fi
-
-# Generate qlib bin tarball and upload it as a GitHub release asset.
-# Requires a GitHub personal access token in $GITHUB_PAT (or $GH_TOKEN / $GITHUB_TOKEN).
-
-TOKEN="${GITHUB_PAT:-${GH_TOKEN:-${GITHUB_TOKEN:-}}}"
-if [[ -z "${TOKEN}" ]]; then
-  echo "Error: GITHUB_PAT environment variable is not set." >&2
-  exit 1
-fi
-
-# Determine repository (owner/repo)
-REPO="${REPO:-${GITHUB_REPOSITORY:-chenditc/investment_data}}"
-
-DATE="${DATE:-$(date +%F)}"
-ASSET_NAME="qlib_bin.tar.gz"
-BODY="Daily update release"
-LOCK_FILE="${UPLOAD_RELEASE_LOCK_FILE:-/tmp/investment_data_upload_release.lock}"
-
-if command -v flock >/dev/null 2>&1; then
-  exec 9>"${LOCK_FILE}"
-  if ! flock -n 9; then
-    echo "Another upload_release.sh is already running; skipping release ${DATE} at $(date -Is)." >&2
-    exit 0
-  fi
-else
-  echo "Warning: flock is not available; continuing without upload_release lock." >&2
-fi
-
-# Ensure jq is available
-if ! command -v jq >/dev/null 2>&1; then
-  echo "Error: jq is required but not installed." >&2
-  exit 1
-fi
-
-# Run dump script to generate the tarball. Release uploads should fail closed
-# when the source data or generated archive is stale.
-CHECK_FRESHNESS="${CHECK_FRESHNESS:-1}" bash dump_qlib_bin.sh
-
-FILE_PATH="$(pwd)/${ASSET_NAME}"
-if [[ ! -f "${FILE_PATH}" ]]; then
-  echo "Error: ${FILE_PATH} not found" >&2
-  exit 1
-fi
-
-API="https://api.github.com/repos/${REPO}"
-AUTH_HEADER="Authorization: token ${TOKEN}"
-
-# Get or create release
-RELEASE_ID=$(curl -sSL -H "${AUTH_HEADER}" "${API}/releases/tags/${DATE}" | jq -r '.id' 2>/dev/null || true)
-if [[ -z "${RELEASE_ID}" || "${RELEASE_ID}" == "null" ]]; then
-  RELEASE_ID=$(curl -fsSL --retry 3 --retry-delay 10 -H "${AUTH_HEADER}" -H 'Content-Type: application/json' \
-    -d "{\"tag_name\":\"${DATE}\",\"name\":\"${DATE}\",\"body\":\"${BODY}\"}" \
-    "${API}/releases" | jq -r '.id')
-fi
-
-if [[ -z "${RELEASE_ID}" || "${RELEASE_ID}" == "null" ]]; then
-  echo "Error: unable to create or fetch release." >&2
-  exit 1
-fi
-
-# Delete existing asset if present
-ASSET_ID=$(curl -fsSL -H "${AUTH_HEADER}" "${API}/releases/${RELEASE_ID}/assets" | jq -r \
-  ".[] | select(.name==\"${ASSET_NAME}\") | .id")
-if [[ -n "${ASSET_ID}" ]]; then
-  curl -fsSL -X DELETE -H "${AUTH_HEADER}" "${API}/releases/assets/${ASSET_ID}" >/dev/null
-fi
-
-# Upload new asset with retry
-UPLOAD_URL=$(curl -fsSL -H "${AUTH_HEADER}" "${API}/releases/${RELEASE_ID}" | jq -r '.upload_url' | sed 's/{?name,label}//')
-
-MAX_RETRIES=3
-for attempt in $(seq 1 ${MAX_RETRIES}); do
-  echo "Upload attempt ${attempt}/${MAX_RETRIES}..."
-  HTTP_CODE=$(curl -sS -o /tmp/upload_response.json -w "%{http_code}" \
-    -H "${AUTH_HEADER}" -H "Content-Type: application/gzip" \
-    --data-binary "@${FILE_PATH}" "${UPLOAD_URL}?name=${ASSET_NAME}")
-
-  if [[ "${HTTP_CODE}" =~ ^2 ]]; then
-    echo "Upload succeeded (HTTP ${HTTP_CODE})"
-    break
-  fi
-
-  echo "Upload failed (HTTP ${HTTP_CODE}), response:" >&2
-  cat /tmp/upload_response.json >&2
-  echo >&2
-
-  if [[ "${attempt}" -eq "${MAX_RETRIES}" ]]; then
-    echo "Error: upload failed after ${MAX_RETRIES} attempts." >&2
-    exit 1
-  fi
-
-  ASSET_ID=$(curl -fsSL -H "${AUTH_HEADER}" "${API}/releases/${RELEASE_ID}/assets" | jq -r \
-    ".[] | select(.name==\"${ASSET_NAME}\") | .id")
-  if [[ -n "${ASSET_ID}" ]]; then
-    curl -fsSL -X DELETE -H "${AUTH_HEADER}" "${API}/releases/assets/${ASSET_ID}" >/dev/null
-    echo "Deleted partial asset before retry"
-  fi
-
-  sleep 30
-done
-
-UPLOADED_SIZE=$(curl -fsSL -H "${AUTH_HEADER}" "${API}/releases/${RELEASE_ID}/assets" | jq -r \
-  ".[] | select(.name==\"${ASSET_NAME}\") | .size")
-LOCAL_SIZE=$(stat -c%s "${FILE_PATH}" 2>/dev/null || stat -f%z "${FILE_PATH}")
-
-if [[ -z "${UPLOADED_SIZE}" || "${UPLOADED_SIZE}" == "null" ]]; then
-  echo "Error: asset not found in release after upload." >&2
-  exit 1
-fi
-
-if [[ "${UPLOADED_SIZE}" -ne "${LOCAL_SIZE}" ]]; then
-  echo "Error: size mismatch - local=${LOCAL_SIZE} uploaded=${UPLOADED_SIZE}" >&2
-  exit 1
-fi
-
-echo "Verified: uploaded ${ASSET_NAME} (${UPLOADED_SIZE} bytes) to release ${DATE}"


### PR DESCRIPTION
## Root cause

The repository configures qlib normalization with `date_field_name="tradedate"`, but the pinned upstream `Normalize.format_data()` reads a literal `date` column for the final row. Its broad exception handler treats the resulting `KeyError` as an invalid date and silently drops that valid row. The release workflow also disabled freshness validation, so the truncated archive could be published and the metadata-only monitor could still report it as healthy.

## Changed behavior

- Normalize against the configured date field, discard only a genuinely invalid final date value, and propagate missing-column or unexpected failures.
- Build from an immutable Dolt snapshot, derive and bound the target/future dates from that snapshot, and produce a deterministic archive plus a strict provenance manifest.
- Validate archive contents and provenance before release mutation and after download; make normal publication and the fixed historical repair fail closed.
- Add archive-aware monitoring and a fixed, rollback-safe monitor deployment path while preserving the existing notification contract.
- Serialize shared Dolt access between data update and release workflows.

## Historical repair and deployment sequence

The fixed `2026-07-20` repair is intentionally constrained to the captured release and Dolt identities. After this PR is merged and the workflow/code is available on `main`, the repair workflow can rebuild and validate the historical archive, preserve the original asset and repair evidence, install the accepted canonical archive/manifest pair, and verify them by redownload. Monitor deployment follows successful repair verification.

The live fixed historical repair and monitor deployment are intentionally deferred until the merged workflow/code is available. This PR does not claim that the live `2026-07-20` release has already been repaired.

## Validation

- Default suite: 94 tests total, 93 passed and 1 intentional environment-gated skip.
- Pinned in-image normalizer suite: 7 passed.
- Two clean deterministic production builds passed validation and produced byte-identical archives.
- Validated target/latest data date: `2026-07-20`.
- Validated future calendar: `2026-07-21` through `2026-12-31`.

Closes #148