### PR TITLE
Run daily data pipelines on GitHub hosted runners

### DIFF
--- a/.github/workflows/data_update.yml
+++ b/.github/workflows/data_update.yml
@@ -11,24 +11,73 @@ concurrency:
 
 jobs:
   update-data:
-    runs-on: investment-arc
-    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
 
     steps:
-    - name: Run daily update script in container
+    - name: Restore the newest verified Dolt snapshot
+      id: dolt-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ runner.temp }}/investment-data-dolt
+        key: investment-data-dolt-v1-${{ runner.os }}-restore-${{ github.run_id }}
+        restore-keys: |
+          investment-data-dolt-v1-${{ runner.os }}-
+
+    - name: Resolve and verify immutable update image
+      id: image
+      shell: bash
+      run: |
+        set -euo pipefail
+        [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]]
+        image_tag="chenditc/investment_data:sha-${GITHUB_SHA}"
+        for attempt in 1 2 3; do
+          docker pull "$image_tag" && break
+          if [[ "$attempt" == 3 ]]; then
+            exit 1
+          fi
+          sleep "$((attempt * 10))"
+        done
+        image_digest="$(docker image inspect "$image_tag" --format '{{json .RepoDigests}}' \
+          | jq -er '[.[] | select(test("^chenditc/investment_data@sha256:[0-9a-f]{64}$"))] | if length == 1 then .[0] | split("@")[1] else error("ambiguous digest") end')"
+        repository_revision="$(docker image inspect "$image_tag" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
+        [[ "$image_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+        [[ "$repository_revision" == "$GITHUB_SHA" ]]
+        printf 'reference=%s@%s\n' \
+          'chenditc/investment_data' "$image_digest" >>"$GITHUB_OUTPUT"
+
+    - name: Run daily update with bounded resources
       env:
         DOLT_CONFIG_GLOBAL_JSON: ${{ secrets.DOLT_CONFIG_GLOBAL_JSON }}
         DOLT_JWK: ${{ secrets.DOLT_JWK }}
         TUSHARE: ${{ secrets.TUSHARE }}
+        IMAGE_REFERENCE: ${{ steps.image.outputs.reference }}
       run: |
         set -euo pipefail
         docker rm -f daily_dolt_update >/dev/null 2>&1 || true
-        docker volume inspect dolt_update >/dev/null 2>&1 || docker volume create dolt_update >/dev/null
-        docker run --pull always --name daily_dolt_update -v dolt_update:/dolt --rm \
+        mkdir -p "$RUNNER_TEMP/investment-data-dolt"
+        df -h "$RUNNER_TEMP"
+        free -h
+
+        cleanup() {
+          docker rm -f daily_dolt_update >/dev/null 2>&1 || true
+        }
+        trap cleanup EXIT
+
+        docker run --name daily_dolt_update --rm \
+          --memory=12g --memory-swap=12g \
+          -v "$RUNNER_TEMP/investment-data-dolt:/dolt" \
           -e DOLT_CONFIG_GLOBAL_JSON \
           -e DOLT_JWK \
           -e TUSHARE \
-          chenditc/investment_data:latest \
+          -e MALLOC_ARENA_MAX=2 \
+          -e OMP_NUM_THREADS=1 \
+          -e OPENBLAS_NUM_THREADS=1 \
+          -e MKL_NUM_THREADS=1 \
+          -e NUMEXPR_NUM_THREADS=1 \
+          "$IMAGE_REFERENCE" \
           bash -lc '
           set -euo pipefail
           mkdir -p /root/.dolt/creds
@@ -36,4 +85,78 @@ jobs:
           printf "%s\n" "$DOLT_JWK" > /root/.dolt/creds/j6ooicvf6t6a0c18pinnr0p6ao69eglbcsfmmh2247d50.jwk
 
           bash daily_update.sh
-          '
+          ' &
+        run_pid=$!
+
+        (
+          while kill -0 "$run_pid" 2>/dev/null; do
+            date -u
+            docker stats --no-stream \
+              --format 'memory={{.MemUsage}} cpu={{.CPUPerc}} block={{.BlockIO}}' \
+              daily_dolt_update || true
+            df -h "$RUNNER_TEMP"
+            sleep 30
+          done
+        ) &
+        monitor_pid=$!
+
+        set +e
+        wait "$run_pid"
+        status=$?
+        set -e
+        kill "$monitor_pid" >/dev/null 2>&1 || true
+        wait "$monitor_pid" >/dev/null 2>&1 || true
+        exit "$status"
+
+    - name: Verify the pushed Dolt snapshot
+      id: snapshot
+      env:
+        IMAGE_REFERENCE: ${{ steps.image.outputs.reference }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        snapshot="$(
+          docker run --rm \
+            --memory=4g --memory-swap=4g \
+            -v "$RUNNER_TEMP/investment-data-dolt:/dolt" \
+            "$IMAGE_REFERENCE" \
+            bash -lc '
+              set -euo pipefail
+              cd /dolt/investment_data
+              status="$(dolt status)"
+              grep -q "nothing to commit, working tree clean" <<<"$status"
+              dolt fetch --silent origin master
+              local_commit="$(dolt sql -r csv -q "SELECT DOLT_HASHOF('\''HEAD'\'') AS value" | tail -n 1 | tr -d "\r")"
+              remote_commit="$(dolt sql -r csv -q "SELECT DOLT_HASHOF('\''origin/master'\'') AS value" | tail -n 1 | tr -d "\r")"
+              [[ "$local_commit" == "$remote_commit" ]]
+              max_date="$(dolt sql -r csv -q "SELECT MAX(tradedate) AS value FROM final_a_stock_eod_price" | tail -n 1 | tr -d "\r")"
+              price_count="$(dolt sql -r csv -q "SELECT COUNT(*) AS value FROM final_a_stock_eod_price" | tail -n 1 | tr -d "\r")"
+              [[ "$local_commit" =~ ^[0-9a-v]{32}$ ]]
+              [[ "$max_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]
+              [[ "$price_count" =~ ^[1-9][0-9]*$ ]]
+              printf "%s,%s,%s\n" "$local_commit" "$max_date" "$price_count"
+            '
+        )"
+        IFS=, read -r commit max_date price_count <<<"$snapshot"
+        printf 'commit=%s\n' "$commit" >>"$GITHUB_OUTPUT"
+        printf 'max_date=%s\n' "$max_date" >>"$GITHUB_OUTPUT"
+        printf 'price_count=%s\n' "$price_count" >>"$GITHUB_OUTPUT"
+        printf 'Verified Dolt commit=%s max_date=%s rows=%s\n' \
+          "$commit" "$max_date" "$price_count"
+
+    - name: Make the snapshot readable by the cache service
+      env:
+        IMAGE_REFERENCE: ${{ steps.image.outputs.reference }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        docker run --rm \
+          -v "$RUNNER_TEMP/investment-data-dolt:/dolt" \
+          "$IMAGE_REFERENCE" \
+          chmod -R a+rX /dolt
+
+    - name: Save the verified Dolt snapshot
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ runner.temp }}/investment-data-dolt
+        key: investment-data-dolt-v1-${{ runner.os }}-${{ steps.snapshot.outputs.commit }}

--- a/.github/workflows/data_update.yml
+++ b/.github/workflows/data_update.yml
@@ -6,7 +6,7 @@ on:
     - cron: '30 * * * *' # Runs at 30 minutes past the hour, every hour
 
 concurrency:
-  group: investment-data-dolt-volume
+  group: ${{ github.ref == 'refs/heads/main' && 'investment-data-dolt-volume' || format('investment-data-dolt-volume-{0}', github.ref) }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,6 +29,20 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
+        name: Select immutable and production image tags
+        id: image-tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo 'value<<EOF'
+            echo 'chenditc/investment_data:sha-${{ github.sha }}'
+            if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+              echo 'chenditc/investment_data:latest'
+            fi
+            echo EOF
+          } >>"$GITHUB_OUTPUT"
+      -
         name: Build and push
         uses: docker/build-push-action@v3
         with:
@@ -36,6 +50,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
             INVESTMENT_DATA_REVISION=${{ github.sha }}
-          tags: |
-            chenditc/investment_data:latest
-            chenditc/investment_data:sha-${{ github.sha }}
+          tags: ${{ steps.image-tags.outputs.value }}

--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -15,7 +15,7 @@ on:
     - cron: '1 11 * * *' # 19:01 Asia/Shanghai
 
 concurrency:
-  group: investment-data-dolt-volume
+  group: ${{ github.ref == 'refs/heads/main' && 'investment-data-dolt-volume' || format('investment-data-dolt-volume-{0}', github.ref) }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -9,6 +9,7 @@ on:
         default: publish
         options:
           - publish
+          - validate
           - repair-2026-07-20
   schedule:
     - cron: '1 11 * * *' # 19:01 Asia/Shanghai
@@ -19,7 +20,7 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: investment-arc
+    runs-on: ubuntu-latest
     timeout-minutes: 180
     permissions:
       contents: write
@@ -28,22 +29,39 @@ jobs:
       OPERATION: ${{ github.event_name == 'schedule' && 'publish' || inputs.operation }}
 
     steps:
+      - name: Restore the newest verified Dolt snapshot
+        id: dolt-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/investment-data-dolt
+          key: investment-data-dolt-v1-${{ runner.os }}-restore-${{ github.run_id }}
+          restore-keys: |
+            investment-data-dolt-v1-${{ runner.os }}-
+
       - name: Resolve and verify immutable publication image
         id: image
         shell: bash
         run: |
           set -euo pipefail
           [[ "$GITHUB_REPOSITORY" == "chenditc/investment_data" ]]
-          [[ "$GITHUB_REF" == "refs/heads/main" ]]
           [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$GITHUB_EVENT_NAME" == "schedule" || "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]
-          [[ "$OPERATION" == "publish" || "$OPERATION" == "repair-2026-07-20" ]]
+          [[ "$OPERATION" == "publish" || "$OPERATION" == "validate" || "$OPERATION" == "repair-2026-07-20" ]]
           if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
             [[ "$OPERATION" == "publish" ]]
           fi
+          if [[ "$OPERATION" != "validate" ]]; then
+            [[ "$GITHUB_REF" == "refs/heads/main" ]]
+          fi
 
           image_tag="chenditc/investment_data:sha-${GITHUB_SHA}"
-          docker pull "$image_tag"
+          for attempt in 1 2 3; do
+            docker pull "$image_tag" && break
+            if [[ "$attempt" == 3 ]]; then
+              exit 1
+            fi
+            sleep "$((attempt * 10))"
+          done
           image_digest="$(docker image inspect "$image_tag" --format '{{json .RepoDigests}}' \
             | jq -er '[.[] | select(test("^chenditc/investment_data@sha256:[0-9a-f]{64}$"))] | if length == 1 then .[0] | split("@")[1] else error("ambiguous digest") end')"
           repository_revision="$(docker image inspect "$image_tag" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
@@ -64,18 +82,115 @@ jobs:
         run: |
           set -euo pipefail
           docker rm -f upload_tar >/dev/null 2>&1 || true
-          docker volume inspect dolt_update >/dev/null 2>&1 || docker volume create dolt_update >/dev/null
+          mkdir -p "$RUNNER_TEMP/investment-data-dolt" "$RUNNER_TEMP/release-output"
+          df -h "$RUNNER_TEMP"
+          free -h
+
           args=()
           if [[ "$OPERATION" == "repair-2026-07-20" ]]; then
             args=(repair-2026-07-20)
           fi
-          docker run --rm --name upload_tar \
-            -v dolt_update:/dolt \
+
+          cleanup() {
+            docker rm -f upload_tar >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          container_command=(bash upload_release.sh "${args[@]}")
+          if [[ "$OPERATION" == "validate" ]]; then
+            container_command=(bash -lc '
+              set -euo pipefail
+              OUTPUT_DIR=/output bash dump_qlib_bin.sh
+              python3 qlib/validate_archive.py \
+                --archive /output/qlib_bin.tar.gz \
+                --manifest /output/qlib_bin.manifest.json \
+                --expected-tag "$(TZ=Asia/Shanghai date +%F)"
+              sha256sum /output/qlib_bin.tar.gz
+              cat /output/qlib_bin.manifest.json
+            ')
+          fi
+
+          docker run --name upload_tar --rm \
+            --memory=12g --memory-swap=12g \
+            -v "$RUNNER_TEMP/investment-data-dolt:/dolt" \
+            -v "$RUNNER_TEMP/release-output:/output" \
             -e HTTP_PROXY -e http_proxy -e HTTPS_PROXY -e https_proxy -e NO_PROXY -e no_proxy \
             -e GITHUB_ACTIONS -e GITHUB_EVENT_NAME -e GITHUB_REPOSITORY -e GITHUB_REF \
             -e GITHUB_SHA -e GITHUB_RUN_ID -e GITHUB_RUN_ATTEMPT -e GITHUB_TOKEN \
             -e PUBLICATION_IMAGE_DIGEST \
             -e PUBLICATION_BAKED_REPOSITORY_REVISION \
             -e PUBLICATION_BAKED_QLIB_REVISION \
+            -e MALLOC_ARENA_MAX=2 \
+            -e OMP_NUM_THREADS=1 \
+            -e OPENBLAS_NUM_THREADS=1 \
+            -e MKL_NUM_THREADS=1 \
+            -e NUMEXPR_NUM_THREADS=1 \
             "chenditc/investment_data@${PUBLICATION_IMAGE_DIGEST}" \
-            bash upload_release.sh "${args[@]}"
+            "${container_command[@]}" &
+          run_pid=$!
+
+          (
+            while kill -0 "$run_pid" 2>/dev/null; do
+              date -u
+              docker stats --no-stream \
+                --format 'memory={{.MemUsage}} cpu={{.CPUPerc}} block={{.BlockIO}}' \
+                upload_tar || true
+              df -h "$RUNNER_TEMP"
+              sleep 30
+            done
+          ) &
+          monitor_pid=$!
+
+          set +e
+          wait "$run_pid"
+          status=$?
+          set -e
+          kill "$monitor_pid" >/dev/null 2>&1 || true
+          wait "$monitor_pid" >/dev/null 2>&1 || true
+          exit "$status"
+
+      - name: Verify the build snapshot
+        id: snapshot
+        env:
+          PUBLICATION_IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          snapshot="$(
+            docker run --rm \
+              --memory=4g --memory-swap=4g \
+              -v "$RUNNER_TEMP/investment-data-dolt:/dolt" \
+              "chenditc/investment_data@${PUBLICATION_IMAGE_DIGEST}" \
+              bash -lc '
+                set -euo pipefail
+                cd /dolt/investment_data
+                status="$(dolt status)"
+                grep -q "nothing to commit, working tree clean" <<<"$status"
+                commit="$(dolt sql -r csv -q "SELECT DOLT_HASHOF('\''HEAD'\'') AS value" | tail -n 1 | tr -d "\r")"
+                max_date="$(dolt sql -r csv -q "SELECT MAX(tradedate) AS value FROM final_a_stock_eod_price" | tail -n 1 | tr -d "\r")"
+                [[ "$commit" =~ ^[0-9a-v]{32}$ ]]
+                [[ "$max_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]
+                printf "%s,%s\n" "$commit" "$max_date"
+              '
+          )"
+          IFS=, read -r commit max_date <<<"$snapshot"
+          printf 'commit=%s\n' "$commit" >>"$GITHUB_OUTPUT"
+          printf 'max_date=%s\n' "$max_date" >>"$GITHUB_OUTPUT"
+          printf 'Verified build snapshot commit=%s max_date=%s\n' "$commit" "$max_date"
+
+      - name: Make the snapshot readable by the cache service
+        env:
+          PUBLICATION_IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "$RUNNER_TEMP/investment-data-dolt:/dolt" \
+            "chenditc/investment_data@${PUBLICATION_IMAGE_DIGEST}" \
+            chmod -R a+rX /dolt
+
+      - name: Save the verified Dolt snapshot
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/investment-data-dolt
+          key: investment-data-dolt-v1-${{ runner.os }}-${{ steps.snapshot.outputs.commit }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ RUN test "$(git -C /investment_data rev-parse HEAD)" = "${INVESTMENT_DATA_REVISI
     && printf '%s\n' "${INVESTMENT_DATA_REVISION}" > /opt/investment-data/REVISION \
     && printf '%s\n' "${QLIB_REVISION}" > /opt/investment-data/QLIB_REVISION \
     && chmod 0444 /opt/investment-data/REVISION /opt/investment-data/QLIB_REVISION \
-    && PYTHONPATH=/qlib:/qlib/scripts python3 -m unittest discover -s /investment_data/tests -p test_qlib_normalize.py
+    && PYTHONPATH=/qlib:/qlib/scripts python3 -m unittest discover \
+        -s /investment_data/tests -p 'test_qlib_*.py'
 
 # Add a global sitecustomize.py so every Python process defaults to "spawn".
 RUN printf '%s\n' \

--- a/daily_update.sh
+++ b/daily_update.sh
@@ -14,7 +14,10 @@ if ! flock -n 8; then
     exit 1
 fi
 
-[ ! -d "${DOLT_DIR}/investment_data" ] && echo "initializing dolt repo" && cd "${DOLT_DIR}" && dolt clone chenditc/investment_data
+[ ! -d "${DOLT_DIR}/investment_data" ] \
+  && echo "initializing shallow dolt repo" \
+  && cd "${DOLT_DIR}" \
+  && dolt clone --depth 1 --branch master chenditc/investment_data investment_data
 cd "${DOLT_DIR}/investment_data"
 dolt fetch origin master
 dolt reset --hard origin/master

--- a/dump_qlib_bin.sh
+++ b/dump_qlib_bin.sh
@@ -22,11 +22,11 @@ case "${TRACE:-0}" in
     1) set -x ;;
     *) printf 'Error: TRACE must be 0 or 1.\n' >&2; exit 2 ;;
 esac
-if [[ ! "${DUMP_QLIB_MAX_WORKERS:-8}" =~ ^[1-9][0-9]*$ ]]; then
+if [[ ! "${DUMP_QLIB_MAX_WORKERS:-2}" =~ ^[1-9][0-9]*$ ]]; then
     printf 'Error: DUMP_QLIB_MAX_WORKERS must be a positive decimal integer.\n' >&2
     exit 2
 fi
-DUMP_QLIB_MAX_WORKERS="${DUMP_QLIB_MAX_WORKERS:-8}"
+DUMP_QLIB_MAX_WORKERS="${DUMP_QLIB_MAX_WORKERS:-2}"
 
 if [[ -v OUTPUT_DIR ]] && { [[ ! -d "$OUTPUT_DIR" ]] || [[ ! -w "$OUTPUT_DIR" ]]; }; then
     printf 'Error: OUTPUT_DIR must be an existing writable directory.\n' >&2
@@ -136,7 +136,9 @@ fi
 
 if [[ ! -d "$SHARED_DOLT_CHECKOUT/.dolt" ]]; then
     log_step "Cloning Dolt data"
-    (cd "$DOLT_DIR" && dolt clone chenditc/investment_data)
+    (cd "$DOLT_DIR" \
+        && dolt clone --depth 1 --branch master \
+            chenditc/investment_data investment_data)
 fi
 if ! (cd "$SHARED_DOLT_CHECKOUT" && dolt status) | grep -q 'nothing to commit, working tree clean'; then
     printf 'Error: shared Dolt checkout is not clean.\n' >&2
@@ -157,18 +159,13 @@ if [[ ! "$SELECTED_DOLT_COMMIT" =~ ^[0-9a-v]{32}$ ]]; then
 fi
 
 BUILD_ROOT="$(mktemp -d "${WORKING_ROOT%/}/.qlib-build.XXXXXXXX")"
-PRIVATE_DOLT_CHECKOUT="$BUILD_ROOT/dolt/investment_data"
-mkdir -p "$(dirname "$PRIVATE_DOLT_CHECKOUT")"
-cp -a "$SHARED_DOLT_CHECKOUT" "$PRIVATE_DOLT_CHECKOUT"
-flock -u 8
-exec 8>&-
-
-(cd "$PRIVATE_DOLT_CHECKOUT" && dolt checkout -b qlib-build-snapshot "$SELECTED_DOLT_COMMIT")
-PRIVATE_DOLT_COMMIT="$(cd "$PRIVATE_DOLT_CHECKOUT" \
+SNAPSHOT_DOLT_CHECKOUT="$SHARED_DOLT_CHECKOUT"
+(cd "$SNAPSHOT_DOLT_CHECKOUT" && dolt reset --hard "$SELECTED_DOLT_COMMIT")
+SNAPSHOT_DOLT_COMMIT="$(cd "$SNAPSHOT_DOLT_CHECKOUT" \
     && dolt sql -r csv -q "SELECT DOLT_HASHOF('HEAD') AS value" \
     | tail -n 1 | tr -d '\r')"
-if [[ "$PRIVATE_DOLT_COMMIT" != "$SELECTED_DOLT_COMMIT" ]]; then
-    printf 'Error: private Dolt checkout identity mismatch.\n' >&2
+if [[ "$SNAPSHOT_DOLT_COMMIT" != "$SELECTED_DOLT_COMMIT" ]]; then
+    printf 'Error: locked Dolt checkout identity mismatch.\n' >&2
     exit 1
 fi
 
@@ -204,10 +201,6 @@ if ! canonical_date "$RELEASE_TAG"; then
     exit 1
 fi
 
-cd "$PRIVATE_DOLT_CHECKOUT"
-dolt sql-server --host 127.0.0.1 --port 3306 >"$BUILD_ROOT/dolt-sql-server.log" 2>&1 &
-DOLT_SQL_SERVER_PID=$!
-
 query_scalar() {
     DOLT_QUERY="$1" python3 - <<'PY'
 import os
@@ -231,24 +224,41 @@ finally:
 PY
 }
 
-SQL_SERVER_READY=false
-for _ in {1..60}; do
-    if [[ "$(query_scalar "SELECT 1" 2>/dev/null || true)" == "1" ]]; then
-        SQL_SERVER_READY=true
-        break
+start_dolt_sql_server() {
+    local ready=false server_commit
+    (
+        cd "$SNAPSHOT_DOLT_CHECKOUT"
+        exec dolt sql-server --host 127.0.0.1 --port 3306
+    ) >>"$BUILD_ROOT/dolt-sql-server.log" 2>&1 &
+    DOLT_SQL_SERVER_PID=$!
+    for _ in {1..60}; do
+        if [[ "$(query_scalar "SELECT 1" 2>/dev/null || true)" == "1" ]]; then
+            ready=true
+            break
+        fi
+        kill -0 "$DOLT_SQL_SERVER_PID" 2>/dev/null || break
+        sleep 1
+    done
+    if [[ "$ready" != true ]] || ! kill -0 "$DOLT_SQL_SERVER_PID" 2>/dev/null; then
+        printf 'Error: Dolt SQL server did not become ready.\n' >&2
+        exit 1
     fi
-    kill -0 "$DOLT_SQL_SERVER_PID" 2>/dev/null || break
-    sleep 1
-done
-if [[ "$SQL_SERVER_READY" != true ]] || ! kill -0 "$DOLT_SQL_SERVER_PID" 2>/dev/null; then
-    printf 'Error: Dolt SQL server did not become ready.\n' >&2
-    exit 1
-fi
-SERVER_DOLT_COMMIT="$(query_scalar "SELECT DOLT_HASHOF('HEAD')")"
-if [[ "$SERVER_DOLT_COMMIT" != "$SELECTED_DOLT_COMMIT" ]]; then
-    printf 'Error: Dolt SQL server identity mismatch before generation.\n' >&2
-    exit 1
-fi
+    server_commit="$(query_scalar "SELECT DOLT_HASHOF('HEAD')")"
+    if [[ "$server_commit" != "$SELECTED_DOLT_COMMIT" ]]; then
+        printf 'Error: Dolt SQL server identity mismatch before generation.\n' >&2
+        exit 1
+    fi
+}
+
+stop_dolt_sql_server() {
+    if [[ -n "$DOLT_SQL_SERVER_PID" ]]; then
+        kill "$DOLT_SQL_SERVER_PID"
+        wait "$DOLT_SQL_SERVER_PID"
+        DOLT_SQL_SERVER_PID=""
+    fi
+}
+
+start_dolt_sql_server
 
 TARGET_TRADE_DATE="$(query_scalar "SELECT MAX(date) AS value FROM ts_trade_day_calendar WHERE exchange = 'SSE' AND is_open = 1 AND date <= '$RELEASE_TAG'")"
 SOURCE_MAX_DATE="$(query_scalar "SELECT MAX(tradedate) AS value FROM final_a_stock_eod_price")"
@@ -301,6 +311,10 @@ for path in sorted(root.glob("*.csv"), key=lambda value: value.as_posix()):
         writer.writerows(rows)
 PY
 
+log_step "Restarting Dolt SQL server to release export scan cache"
+stop_dolt_sql_server
+start_dolt_sql_server
+
 export PYTHONPATH="${PYTHONPATH:-}:$QLIB_REPO_DIR:$QLIB_REPO_DIR/scripts"
 log_step "Normalizing qlib data with $DUMP_QLIB_MAX_WORKERS workers"
 python3 ./qlib/normalize.py \
@@ -308,14 +322,22 @@ python3 ./qlib/normalize.py \
     --normalize_dir "$QLIB_NORMALIZE_DIR" \
     --max_workers "$DUMP_QLIB_MAX_WORKERS" \
     --date_field_name tradedate \
-    --target_trade_date "$TARGET_TRADE_DATE"
+    --target_trade_date "$TARGET_TRADE_DATE" \
+    --delete_source_after_success=true
 
-log_step "Dumping normalized qlib data to binary files"
-python3 "$QLIB_REPO_DIR/scripts/dump_bin.py" dump_all \
-    --data_path "$QLIB_NORMALIZE_DIR" \
-    --qlib_dir "$QLIB_BIN_DIR" \
-    --date_field_name tradedate \
-    --exclude_fields tradedate,symbol
+if find "$QLIB_SOURCE_DIR" -type f -print -quit | grep -q .; then
+    printf 'Error: normalized qlib source files were not cleaned up.\n' >&2
+    exit 1
+fi
+rmdir "$QLIB_SOURCE_DIR"
+
+log_step "Dumping normalized qlib data to binary files sequentially"
+QLIB_DUMP_BIN_PATH="$QLIB_REPO_DIR/scripts/dump_bin.py" \
+python3 ./qlib/dump_bin_sequential.py \
+    --data-path "$QLIB_NORMALIZE_DIR" \
+    --qlib-dir "$QLIB_BIN_DIR" \
+    --date-field-name tradedate \
+    --exclude-fields tradedate,symbol
 
 log_step "Dumping bounded qlib index constituents"
 QLIB_INDEX_DIR="$QLIB_INDEX_DIR" python3 ./qlib/dump_index_weight.py \
@@ -331,9 +353,9 @@ if [[ "$SERVER_DOLT_COMMIT" != "$SELECTED_DOLT_COMMIT" ]]; then
     printf 'Error: Dolt SQL server identity mismatch after generation.\n' >&2
     exit 1
 fi
-kill "$DOLT_SQL_SERVER_PID"
-wait "$DOLT_SQL_SERVER_PID"
-DOLT_SQL_SERVER_PID=""
+stop_dolt_sql_server
+flock -u 8
+exec 8>&-
 
 SOURCE_DATE_EPOCH="$(date -u -d "$RELEASE_TAG 00:00:00Z" +%s)"
 export LC_ALL=C TZ=UTC SOURCE_DATE_EPOCH

--- a/qlib/dump_all_to_qlib_source.py
+++ b/qlib/dump_all_to_qlib_source.py
@@ -1,26 +1,84 @@
-from sqlalchemy import create_engine
-import pymysql
-import pandas as pd
 import fire
 import os
+from pathlib import Path
 
-def dump_all_to_sqlib_source(skip_exists=False):
-  sqlEngine = create_engine('mysql+pymysql://root:@127.0.0.1/investment_data', pool_recycle=3600)
-  dbConnection = sqlEngine.raw_connection()
-  stock_df = pd.read_sql("select *, amount/volume*10 as vwap from final_a_stock_eod_price", dbConnection)
-  dbConnection.close()
-  sqlEngine.dispose()
+import pandas as pd
+from sqlalchemy import create_engine, text
 
+
+EXPORT_QUERY = """
+select *, amount / volume * 10 as vwap
+from final_a_stock_eod_price
+order by symbol, tradedate
+"""
+
+
+def _write_symbol_chunks(chunks, output_dir, skip_exists=False):
+  output_dir = Path(output_dir)
+  output_dir.mkdir(parents=True, exist_ok=True)
+  preexisting = {path.name for path in output_dir.glob("*.csv")} if skip_exists else set()
+  emitted = set()
+  row_count = 0
+
+  for chunk in chunks:
+    if chunk.empty:
+      continue
+    if "symbol" not in chunk.columns:
+      raise ValueError("export query did not return a symbol column")
+    row_count += len(chunk)
+    for symbol, frame in chunk.groupby("symbol", sort=False):
+      filename = f"{symbol}.csv"
+      if filename in preexisting:
+        continue
+      path = output_dir / filename
+      first_write = filename not in emitted
+      frame.to_csv(
+        path,
+        index=False,
+        mode="w" if first_write else "a",
+        header=first_write,
+      )
+      emitted.add(filename)
+
+  if row_count == 0:
+    raise ValueError("final_a_stock_eod_price export returned no rows")
+  if not emitted and not preexisting:
+    raise ValueError("final_a_stock_eod_price export produced no symbol files")
+  return row_count, len(emitted)
+
+
+def dump_all_to_sqlib_source(skip_exists=False, chunk_rows=50000):
+  if not isinstance(chunk_rows, int) or isinstance(chunk_rows, bool) or chunk_rows <= 0:
+    raise ValueError("chunk_rows must be a positive integer")
   script_path = os.path.dirname(os.path.realpath(__file__))
   output_dir = os.environ.get("QLIB_SOURCE_DIR", f'{script_path}/qlib_source')
-  os.makedirs(output_dir, exist_ok=True)
 
-  for symbol, df in stock_df.groupby("symbol"):
-    filename = f'{output_dir}/{symbol}.csv'
-    print("Dumping to file: ", filename)
-    if skip_exists and os.path.isfile(filename):
-        continue
-    df.to_csv(filename, index=False)
+  sql_engine = create_engine(
+    "mysql+pymysql://root:@127.0.0.1/investment_data",
+    pool_recycle=3600,
+  )
+  try:
+    with sql_engine.connect().execution_options(
+      stream_results=True,
+      max_row_buffer=chunk_rows,
+    ) as connection:
+      chunks = pd.read_sql_query(
+        text(EXPORT_QUERY),
+        connection,
+        chunksize=chunk_rows,
+      )
+      row_count, symbol_count = _write_symbol_chunks(
+        chunks,
+        output_dir,
+        skip_exists=skip_exists,
+      )
+  finally:
+    sql_engine.dispose()
+
+  print(
+    f"Exported {row_count} rows into {symbol_count} symbol CSV files "
+    f"with chunks of at most {chunk_rows} rows"
+  )
 
 if __name__ == "__main__":
   fire.Fire(dump_all_to_sqlib_source)

--- a/qlib/dump_bin_sequential.py
+++ b/qlib/dump_bin_sequential.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+import argparse
+import importlib.util
+import os
+from pathlib import Path
+
+import pandas as pd
+
+
+def _load_pinned_dump_module():
+    path = Path(os.environ["QLIB_DUMP_BIN_PATH"]).resolve()
+    if not path.is_file():
+        raise ValueError(f"pinned qlib dump_bin.py is unavailable: {path}")
+    spec = importlib.util.spec_from_file_location("pinned_qlib_dump_bin", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+PINNED_DUMP = _load_pinned_dump_module()
+
+
+class SequentialDumpDataAll(PINNED_DUMP.DumpDataAll):
+    """Preserve qlib dump semantics without its eager process-pool deadlock."""
+
+    def _get_all_date(self):
+        all_datetime = set()
+        date_range_list = []
+        for file_path in self.df_files:
+            (begin_time, end_time), calendars = self._get_date(
+                file_path,
+                as_set=True,
+                is_begin_end=True,
+            )
+            all_datetime.update(calendars)
+            if isinstance(begin_time, pd.Timestamp) and isinstance(
+                end_time, pd.Timestamp
+            ):
+                symbol = self.get_symbol_from_file(file_path)
+                date_range_list.append(
+                    self.INSTRUMENTS_SEP.join(
+                        (
+                            symbol.upper(),
+                            self._format_datetime(begin_time),
+                            self._format_datetime(end_time),
+                        )
+                    )
+                )
+        self._kwargs["all_datetime_set"] = all_datetime
+        self._kwargs["date_range_list"] = date_range_list
+
+    def _dump_features(self):
+        for file_path in self.df_files:
+            self._dump_bin(file_path, self._calendars_list)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-path", required=True)
+    parser.add_argument("--qlib-dir", required=True)
+    parser.add_argument("--date-field-name", required=True)
+    parser.add_argument("--exclude-fields", required=True)
+    arguments = parser.parse_args()
+    dumper = SequentialDumpDataAll(
+        data_path=arguments.data_path,
+        qlib_dir=arguments.qlib_dir,
+        max_workers=1,
+        date_field_name=arguments.date_field_name,
+        exclude_fields=arguments.exclude_fields,
+    )
+    dumper.dump()
+
+
+if __name__ == "__main__":
+    main()

--- a/qlib/normalize.py
+++ b/qlib/normalize.py
@@ -48,12 +48,18 @@ class _DateFieldAwareNormalize(Normalize):
       return df.iloc[:-1]
     return df
 
+  def _executor_with_source_cleanup(self, file_path):
+    result = self._executor(file_path)
+    if getattr(self, "_delete_source_after_success", False):
+      file_path.unlink()
+    return result
+
   def normalize(self):
     # Upstream uses filesystem enumeration order. Sorting keeps fixed-input
     # builds independent of directory iteration order.
     file_list = sorted(self._source_dir.glob("*.csv"), key=lambda path: path.as_posix())
     with ProcessPoolExecutor(max_workers=self._max_workers) as worker:
-      for _ in worker.map(self._executor, file_list):
+      for _ in worker.map(self._executor_with_source_cleanup, file_list):
         pass
 
 
@@ -108,6 +114,7 @@ def normalize_crowd_source_data(
     date_field_name="tradedate",
     symbol_field_name="symbol",
     target_trade_date: Optional[str] = None,
+    delete_source_after_success=False,
 ):
     import multiprocessing as mp
     mp.set_start_method("spawn", force=True)
@@ -121,6 +128,7 @@ def normalize_crowd_source_data(
         symbol_field_name=symbol_field_name,
         interval=interval,
     )
+    yc._delete_source_after_success = delete_source_after_success
     yc.normalize()
 
 if __name__ == "__main__":

--- a/tests/test_qlib_dump_bin_sequential.py
+++ b/tests/test_qlib_dump_bin_sequential.py
@@ -1,0 +1,82 @@
+import importlib.util
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+import pandas as pd
+
+
+def _load_module():
+    temporary = tempfile.TemporaryDirectory()
+    pinned = Path(temporary.name) / "dump_bin.py"
+    pinned.write_text("class DumpDataAll:\n    pass\n", encoding="utf-8")
+    path = Path(__file__).resolve().parents[1] / "qlib/dump_bin_sequential.py"
+    spec = importlib.util.spec_from_file_location("tested_dump_bin_sequential", path)
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(os.environ, {"QLIB_DUMP_BIN_PATH": str(pinned)}):
+        spec.loader.exec_module(module)
+    return temporary, module
+
+
+TEMPORARY, MODULE = _load_module()
+
+
+class SequentialDumpDataAllTest(unittest.TestCase):
+    @classmethod
+    def tearDownClass(cls):
+        TEMPORARY.cleanup()
+
+    def make_dumper(self):
+        dumper = MODULE.SequentialDumpDataAll.__new__(MODULE.SequentialDumpDataAll)
+        dumper.df_files = [Path("a.csv"), Path("b.csv")]
+        dumper.INSTRUMENTS_SEP = "\t"
+        dumper._kwargs = {}
+        dumper._get_date = mock.Mock(
+            side_effect=[
+                (
+                    (pd.Timestamp("2026-07-23"), pd.Timestamp("2026-07-24")),
+                    {pd.Timestamp("2026-07-23"), pd.Timestamp("2026-07-24")},
+                ),
+                (
+                    (pd.Timestamp("2026-07-24"), pd.Timestamp("2026-07-24")),
+                    {pd.Timestamp("2026-07-24")},
+                ),
+            ]
+        )
+        dumper.get_symbol_from_file = mock.Mock(side_effect=["sh600000", "sz000001"])
+        dumper._format_datetime = lambda value: value.strftime("%Y-%m-%d")
+        return dumper
+
+    def test_date_and_instrument_collection_matches_sorted_input_order(self):
+        dumper = self.make_dumper()
+        dumper._get_all_date()
+        self.assertEqual(
+            dumper._kwargs["all_datetime_set"],
+            {pd.Timestamp("2026-07-23"), pd.Timestamp("2026-07-24")},
+        )
+        self.assertEqual(
+            dumper._kwargs["date_range_list"],
+            [
+                "SH600000\t2026-07-23\t2026-07-24",
+                "SZ000001\t2026-07-24\t2026-07-24",
+            ],
+        )
+
+    def test_features_are_dumped_sequentially_in_file_order(self):
+        dumper = self.make_dumper()
+        dumper._calendars_list = [pd.Timestamp("2026-07-24")]
+        dumper._dump_bin = mock.Mock()
+        dumper._dump_features()
+        self.assertEqual(
+            dumper._dump_bin.call_args_list,
+            [
+                mock.call(Path("a.csv"), dumper._calendars_list),
+                mock.call(Path("b.csv"), dumper._calendars_list),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qlib_normalize.py
+++ b/tests/test_qlib_normalize.py
@@ -6,6 +6,7 @@ import types
 from typing import Optional
 import unittest
 from unittest import mock
+import tempfile
 
 import pandas as pd
 
@@ -133,6 +134,32 @@ class DateFieldAwareNormalizeTest(unittest.TestCase):
         self.assertIn("date <= CURRENT_DATE", read_sql.call_args.args[0])
         connection.close.assert_called_once_with()
         engine.dispose.assert_called_once_with()
+
+    def test_source_is_deleted_only_after_successful_normalization(self):
+        normalizer = MODULE._DateFieldAwareNormalize.__new__(
+            MODULE._DateFieldAwareNormalize
+        )
+        normalizer._delete_source_after_success = True
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "SH600000.csv"
+            source.write_text("tradedate,close\n2026-07-24,10\n", encoding="utf-8")
+            normalizer._executor = mock.Mock(return_value=None)
+            normalizer._executor_with_source_cleanup(source)
+            normalizer._executor.assert_called_once_with(source)
+            self.assertFalse(source.exists())
+
+    def test_source_is_preserved_when_normalization_fails(self):
+        normalizer = MODULE._DateFieldAwareNormalize.__new__(
+            MODULE._DateFieldAwareNormalize
+        )
+        normalizer._delete_source_after_success = True
+        with tempfile.TemporaryDirectory() as temporary:
+            source = Path(temporary) / "SH600000.csv"
+            source.write_text("tradedate,close\n2026-07-24,10\n", encoding="utf-8")
+            normalizer._executor = mock.Mock(side_effect=RuntimeError("normalize failed"))
+            with self.assertRaisesRegex(RuntimeError, "normalize failed"):
+                normalizer._executor_with_source_cleanup(source)
+            self.assertTrue(source.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_qlib_source_export.py
+++ b/tests/test_qlib_source_export.py
@@ -1,0 +1,93 @@
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import types
+import unittest
+
+import pandas as pd
+
+
+def _load_module():
+    try:
+        import fire  # noqa: F401
+    except ImportError:
+        fire = types.ModuleType("fire")
+        fire.Fire = lambda *_args, **_kwargs: None
+        sys.modules["fire"] = fire
+    path = Path(__file__).resolve().parents[1] / "qlib/dump_all_to_qlib_source.py"
+    spec = importlib.util.spec_from_file_location("tested_qlib_source_export", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+
+
+class QlibSourceExportTest(unittest.TestCase):
+    def test_split_symbols_are_appended_with_one_header(self):
+        chunks = [
+            pd.DataFrame(
+                {
+                    "symbol": ["SH600000", "SH600000", "SZ000001"],
+                    "tradedate": ["2026-07-23", "2026-07-24", "2026-07-23"],
+                    "close": [10.0, 10.1, 12.0],
+                }
+            ),
+            pd.DataFrame(
+                {
+                    "symbol": ["SZ000001", "SZ000002"],
+                    "tradedate": ["2026-07-24", "2026-07-24"],
+                    "close": [12.1, 8.0],
+                }
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as temporary:
+            row_count, symbol_count = MODULE._write_symbol_chunks(chunks, temporary)
+            self.assertEqual(row_count, 5)
+            self.assertEqual(symbol_count, 3)
+            frame = pd.read_csv(Path(temporary) / "SZ000001.csv")
+            self.assertEqual(frame["tradedate"].tolist(), ["2026-07-23", "2026-07-24"])
+            self.assertEqual(
+                (Path(temporary) / "SZ000001.csv")
+                .read_text(encoding="utf-8")
+                .count("symbol,tradedate,close"),
+                1,
+            )
+
+    def test_empty_export_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            with self.assertRaisesRegex(ValueError, "returned no rows"):
+                MODULE._write_symbol_chunks([], temporary)
+
+    def test_missing_symbol_column_fails_closed(self):
+        chunks = [pd.DataFrame({"tradedate": ["2026-07-24"]})]
+        with tempfile.TemporaryDirectory() as temporary:
+            with self.assertRaisesRegex(ValueError, "symbol column"):
+                MODULE._write_symbol_chunks(chunks, temporary)
+
+    def test_skip_exists_does_not_overwrite_preexisting_symbol(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            existing = Path(temporary) / "SH600000.csv"
+            existing.write_text("sentinel\n", encoding="utf-8")
+            chunks = [
+                pd.DataFrame(
+                    {
+                        "symbol": ["SH600000", "SZ000001"],
+                        "tradedate": ["2026-07-24", "2026-07-24"],
+                    }
+                )
+            ]
+            row_count, symbol_count = MODULE._write_symbol_chunks(
+                chunks,
+                temporary,
+                skip_exists=True,
+            )
+            self.assertEqual(row_count, 2)
+            self.assertEqual(symbol_count, 1)
+            self.assertEqual(existing.read_text(encoding="utf-8"), "sentinel\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_safety.py
+++ b/tests/test_release_safety.py
@@ -645,8 +645,13 @@ class StaticSafetyContractTest(unittest.TestCase):
         data = (ROOT / ".github/workflows/data_update.yml").read_text()
         image = (ROOT / ".github/workflows/docker-image.yml").read_text()
         dockerfile = (ROOT / "Dockerfile").read_text()
-        self.assertEqual(upload.count("group: investment-data-dolt-volume"), 1)
-        self.assertEqual(data.count("group: investment-data-dolt-volume"), 1)
+        concurrency_group = (
+            "group: ${{ github.ref == 'refs/heads/main' && "
+            "'investment-data-dolt-volume' || "
+            "format('investment-data-dolt-volume-{0}', github.ref) }}"
+        )
+        self.assertEqual(upload.count(concurrency_group), 1)
+        self.assertEqual(data.count(concurrency_group), 1)
         self.assertNotIn("CHECK_FRESHNESS", upload)
         self.assertNotIn("svenstaro/upload-release-action", upload)
         self.assertIn("permissions:\n      contents: write", upload)

--- a/tests/test_release_safety.py
+++ b/tests/test_release_safety.py
@@ -655,6 +655,7 @@ class StaticSafetyContractTest(unittest.TestCase):
         self.assertNotIn("chenditc/investment_data:latest", upload)
         self.assertIn("sha-${{ github.sha }}", image)
         self.assertIn("INVESTMENT_DATA_REVISION=${{ github.sha }}", image)
+        self.assertIn('if [[ "$GITHUB_REF" == "refs/heads/main" ]]', image)
         self.assertIn(QLIB_COMMIT, dockerfile)
         self.assertIn("org.opencontainers.image.revision", dockerfile)
         self.assertIn("/opt/investment-data/REVISION", dockerfile)
@@ -671,7 +672,10 @@ class StaticSafetyContractTest(unittest.TestCase):
         self.assertEqual(operation["required"], "true")
         self.assertEqual(operation["type"], "choice")
         self.assertEqual(operation["default"], "publish")
-        self.assertEqual(operation["options"], ["publish", "repair-2026-07-20"])
+        self.assertEqual(
+            operation["options"],
+            ["publish", "validate", "repair-2026-07-20"],
+        )
 
     def test_dump_and_uploader_public_grammars_fail_before_work(self):
         dump = subprocess.run(["bash", str(ROOT / "dump_qlib_bin.sh"), "a", "b", "c"], text=True, capture_output=True)
@@ -1020,9 +1024,13 @@ if [[ -n "${MANIFEST_PATH:-}" ]]; then
   exit 0
 fi
 arguments="$*"
-if [[ "$arguments" == *dump_bin.py* ]]; then
+if [[ "$arguments" == *dump_bin.py* || "$arguments" == *dump_bin_sequential.py* ]]; then
   while (($#)); do
-    if [[ "$1" == --qlib_dir ]]; then shift; qlib_dir=$1; break; fi
+    if [[ "$1" == --qlib_dir || "$1" == --qlib-dir ]]; then
+      shift
+      qlib_dir=$1
+      break
+    fi
     shift
   done
   mkdir -p "$qlib_dir/calendars" "$qlib_dir/instruments"
@@ -1110,9 +1118,30 @@ exit 0
         self.assertNotIn("write_text(", calendar)
         self.assertIn("target_trade_date=None", normalize)
         self.assertIn("_DateFieldAwareNormalize", normalize)
-        self.assertIn('--data_path "$QLIB_NORMALIZE_DIR"', dump)
+        self.assertIn('--data-path "$QLIB_NORMALIZE_DIR"', dump)
+        self.assertIn("dump_bin_sequential.py", dump)
+        self.assertIn("--delete_source_after_success=true", dump)
         self.assertNotIn("dump_bin_help", dump)
         self.assertNotIn("--csv_path", dump)
+
+    def test_hosted_workflows_bound_resources_and_use_shallow_snapshot_cache(self):
+        update = (ROOT / ".github/workflows/data_update.yml").read_text()
+        upload = (ROOT / ".github/workflows/upload_release.yml").read_text()
+        daily = (ROOT / "daily_update.sh").read_text()
+        publisher = (ROOT / "upload_release.sh").read_text()
+        dump = (ROOT / "dump_qlib_bin.sh").read_text()
+        for workflow in (update, upload):
+            self.assertIn("runs-on: ubuntu-latest", workflow)
+            self.assertIn("actions/cache/restore@v4", workflow)
+            self.assertIn("actions/cache/save@v4", workflow)
+            self.assertIn("--memory=12g", workflow)
+            self.assertIn("chmod -R a+rX /dolt", workflow)
+            self.assertNotIn("runs-on: investment-arc", workflow)
+            self.assertNotIn("docker volume", workflow)
+        for script in (daily, publisher, dump):
+            self.assertIn("dolt clone --depth 1 --branch master", script)
+        self.assertNotIn('cp -a "$SHARED_DOLT_CHECKOUT"', dump)
+        self.assertIn('SNAPSHOT_DOLT_CHECKOUT="$SHARED_DOLT_CHECKOUT"', dump)
 
     def test_dolt_identities_use_machine_readable_hash_queries(self):
         dump = (ROOT / "dump_qlib_bin.sh").read_text()

--- a/upload_release.sh
+++ b/upload_release.sh
@@ -291,7 +291,9 @@ select_normal_dolt_commit() {
         || { die "shared Dolt checkout lock is held"; return 1; }
     if [[ ! -d "$checkout/.dolt" ]]; then
         printf 'Cloning shared Dolt checkout.\n' >&2
-        (cd "$dolt_dir" && dolt clone chenditc/investment_data) >&2 \
+        (cd "$dolt_dir" \
+            && dolt clone --depth 1 --branch master \
+                chenditc/investment_data investment_data) >&2 \
             || { die "failed to clone shared Dolt checkout"; return 1; }
     fi
     status_output="$(cd "$checkout" && dolt status)" \


### PR DESCRIPTION
## Summary

- move data update and qlib release workflows to GitHub-hosted `ubuntu-latest` runners
- use verified shallow Dolt snapshots with cache cold fallback
- stream the 18.26M-row export, bound normalize workers, and dump qlib features sequentially
- verify immutable image, Dolt commit, row/date invariants, archive manifest, and release assets

## Validation

- hosted update run 30158496646: success, clean idempotent rerun, commit `gj2o1t8j4vanv6nk7q2kioe0gnkf17t3`, 18,260,412 rows, max date 2026-07-24
- hosted upload validate run 30158859930: success, 18,260,412 rows / 6,123 symbols, peak container memory ~7.032 GiB
- archive: 558,628,906 bytes, sha256 `0cef02661e211d53fdfceaadcb86dd774cc746c290e308458070dd4a24a1ddee`; matches the independent local full build
- local tests: 15 qlib low-memory tests and 74 core release safety tests passed (1 conditional skip)