### PR TITLE
Make scheduled releases resilient to cron drops

### DIFF
--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Check out exact source commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -12,7 +12,8 @@ on:
           - validate
           - repair-2026-07-20
   schedule:
-    - cron: '1 11 * * *' # 19:01 Asia/Shanghai
+    - cron: '47 10 * * *' # 18:47 Asia/Shanghai: early fresh-data opportunity
+    - cron: '17 11,12 * * *' # 19:17 and 20:17 Asia/Shanghai: staggered fallbacks
 
 concurrency:
   group: ${{ github.ref == 'refs/heads/main' && 'investment-data-dolt-volume' || format('investment-data-dolt-volume-{0}', github.ref) }}
@@ -23,14 +24,38 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     permissions:
-      actions: read
       contents: write
+      actions: read
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       OPERATION: ${{ github.event_name == 'schedule' && 'publish' || inputs.operation }}
 
     steps:
+      - name: Check out exact source commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Decide whether publication is needed
+        id: publication-gate
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$OPERATION" == "publish" ]]; then
+            mode="$(bash release_gate.sh)"
+          else
+            mode=build
+          fi
+          [[ "$mode" == "publish" || "$mode" == "validate-existing" \
+            || "$mode" == "skip" || "$mode" == "build" ]]
+          printf 'mode=%s\n' "$mode" >>"$GITHUB_OUTPUT"
+          printf 'Publication gate mode: %s\n' "$mode"
+
       - name: Resolve the newest cached Dolt snapshot
+        if: ${{ steps.publication-gate.outputs.mode == 'publish' || steps.publication-gate.outputs.mode == 'build' }}
         id: dolt-cache-key
         env:
           GH_TOKEN: ${{ github.token }}
@@ -67,7 +92,7 @@ jobs:
           fi
 
       - name: Restore the newest verified Dolt snapshot
-        if: ${{ steps.dolt-cache-key.outputs.key != '' }}
+        if: ${{ (steps.publication-gate.outputs.mode == 'publish' || steps.publication-gate.outputs.mode == 'build') && steps.dolt-cache-key.outputs.key != '' }}
         id: dolt-cache
         uses: actions/cache/restore@v6
         with:
@@ -75,6 +100,7 @@ jobs:
           key: ${{ steps.dolt-cache-key.outputs.key }}
 
       - name: Resolve and verify immutable publication image
+        if: ${{ steps.publication-gate.outputs.mode != 'skip' }}
         id: image
         shell: bash
         run: |
@@ -110,6 +136,7 @@ jobs:
           printf 'qlib_revision=%s\n' "$qlib_revision" >>"$GITHUB_OUTPUT"
 
       - name: Build, validate, and publish release assets
+        if: ${{ steps.publication-gate.outputs.mode != 'skip' }}
         shell: bash
         env:
           PUBLICATION_IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
@@ -125,6 +152,8 @@ jobs:
           args=()
           if [[ "$OPERATION" == "repair-2026-07-20" ]]; then
             args=(repair-2026-07-20)
+          elif [[ "${{ steps.publication-gate.outputs.mode }}" == "validate-existing" ]]; then
+            args=(validate-existing)
           fi
 
           cleanup() {
@@ -186,6 +215,7 @@ jobs:
           exit "$status"
 
       - name: Verify the build snapshot
+        if: ${{ steps.publication-gate.outputs.mode == 'publish' || steps.publication-gate.outputs.mode == 'build' }}
         id: snapshot
         env:
           PUBLICATION_IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
@@ -215,6 +245,7 @@ jobs:
           printf 'Verified build snapshot commit=%s max_date=%s\n' "$commit" "$max_date"
 
       - name: Check whether the verified snapshot is already cached
+        if: ${{ steps.publication-gate.outputs.mode == 'publish' || steps.publication-gate.outputs.mode == 'build' }}
         id: verified-cache
         env:
           GH_TOKEN: ${{ github.token }}
@@ -242,6 +273,7 @@ jobs:
           printf 'Verified snapshot cache exists: %s\n' "$exists"
 
       - name: Make the snapshot readable by the cache service
+        if: ${{ steps.publication-gate.outputs.mode == 'publish' || steps.publication-gate.outputs.mode == 'build' }}
         env:
           PUBLICATION_IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
         shell: bash
@@ -253,7 +285,7 @@ jobs:
             chmod -R a+rX /dolt
 
       - name: Save the verified Dolt snapshot
-        if: ${{ steps.dolt-cache.outputs.cache-matched-key != format('investment-data-dolt-v2-{0}-{1}', runner.os, steps.snapshot.outputs.commit) && steps.verified-cache.outputs.exists != 'true' }}
+        if: ${{ (steps.publication-gate.outputs.mode == 'publish' || steps.publication-gate.outputs.mode == 'build') && steps.dolt-cache.outputs.cache-matched-key != format('investment-data-dolt-v2-{0}-{1}', runner.os, steps.snapshot.outputs.commit) && steps.verified-cache.outputs.exists != 'true' }}
         uses: actions/cache/save@v6
         with:
           path: ${{ runner.temp }}/investment-data-dolt

--- a/release_gate.sh
+++ b/release_gate.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPOSITORY="chenditc/investment_data"
+API_ROOT="https://api.github.com/repos/${REPOSITORY}"
+DOLTHUB_API_ROOT="https://www.dolthub.com/api/v1alpha1/chenditc/investment_data/master"
+ARCHIVE_NAME="qlib_bin.tar.gz"
+MANIFEST_NAME="qlib_bin.manifest.json"
+
+die() {
+    printf 'Error: %s\n' "$*" >&2
+    return 1
+}
+
+usage() {
+    printf 'usage: %s\n' "${0##*/}" >&2
+}
+
+canonical_date() {
+    local value=$1
+    [[ "$value" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] \
+        && [[ "$(date -u -d "$value" +%F 2>/dev/null)" == "$value" ]]
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 \
+        || { die "required command is unavailable: $1"; return 1; }
+}
+
+preflight() {
+    [[ "${GITHUB_ACTIONS:-}" == "true" ]] \
+        || { die "release gate requires GitHub Actions authority"; return 1; }
+    [[ "${GITHUB_EVENT_NAME:-}" == "schedule" \
+        || "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]] \
+        || { die "release gate requires schedule or workflow_dispatch"; return 1; }
+    [[ "${GITHUB_REPOSITORY:-}" == "$REPOSITORY" ]] \
+        || { die "unexpected GitHub repository"; return 1; }
+    [[ "${GITHUB_REF:-}" == "refs/heads/main" ]] \
+        || { die "release gate requires main branch authority"; return 1; }
+    [[ "${OPERATION:-}" == "publish" ]] \
+        || { die "release gate only supports publish"; return 1; }
+    [[ -n "${GITHUB_TOKEN:-}" ]] \
+        || { die "GITHUB_TOKEN is required"; return 1; }
+    for command in cat curl jq date mktemp rm; do
+        require_command "$command" || return 1
+    done
+}
+
+github_get_release_by_tag_optional() {
+    local tag=$1 response_file status curl_status=0
+    response_file="$(mktemp /tmp/investment-data-release-gate.XXXXXXXX)" \
+        || return 1
+    status="$(curl -sS -o "$response_file" -w '%{http_code}' \
+        --retry 3 --retry-delay 2 \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -H "Accept: application/vnd.github+json" \
+        "${API_ROOT}/releases/tags/${tag}")" || curl_status=$?
+    if ((curl_status != 0)); then
+        rm -f -- "$response_file"
+        die "GitHub release lookup failed"
+        return 1
+    fi
+    case "$status" in
+        200)
+            cat "$response_file"
+            rm -f -- "$response_file"
+            ;;
+        404)
+            rm -f -- "$response_file"
+            return 4
+            ;;
+        *)
+            rm -f -- "$response_file"
+            die "GitHub release lookup failed with HTTP $status"
+            return 1
+            ;;
+    esac
+}
+
+release_identity_is_valid() {
+    local release=$1 tag=$2
+    jq -e --arg tag "$tag" '
+        (.id | type) == "number"
+        and .id > 0
+        and .tag_name == $tag
+        and .draft == false
+        and .prerelease == false
+        and (.assets | type) == "array"
+    ' >/dev/null 2>&1 <<<"$release"
+}
+
+release_is_complete() {
+    local release=$1
+    jq -e --arg archive "$ARCHIVE_NAME" --arg manifest "$MANIFEST_NAME" '
+        (.assets | length) == 2
+        and ([.assets[].name] | sort) == ([$archive, $manifest] | sort)
+        and all(.assets[];
+            .state == "uploaded"
+            and (.size | type) == "number"
+            and .size > 0
+            and (.digest | type) == "string"
+            and (.digest | test("^sha256:[0-9a-f]{64}$"))
+        )
+    ' >/dev/null 2>&1 <<<"$release"
+}
+
+query_freshness() {
+    local tag=$1 sql response values source_max_date target_trade_date
+    sql="SELECT (SELECT MAX(tradedate) FROM final_a_stock_eod_price) AS source_max_date, (SELECT MAX(date) FROM ts_trade_day_calendar WHERE exchange = 'SSE' AND is_open = 1 AND date <= '${tag}') AS target_trade_date"
+    response="$(curl -fsSL --retry 3 --retry-delay 2 --get \
+        "$DOLTHUB_API_ROOT" --data-urlencode "q=$sql")" \
+        || { die "DoltHub freshness query failed"; return 1; }
+    values="$(jq -er '
+        select(.query_execution_status == "Success")
+        | .rows
+        | if length == 1 then .[0] else error("unexpected row count") end
+        | [.source_max_date, .target_trade_date]
+        | @tsv
+    ' <<<"$response")" \
+        || { die "DoltHub freshness response is invalid"; return 1; }
+    IFS=$'\t' read -r source_max_date target_trade_date <<<"$values"
+    canonical_date "$source_max_date" \
+        || { die "source max date is invalid"; return 1; }
+    canonical_date "$target_trade_date" \
+        || { die "target trade date is invalid"; return 1; }
+    printf '%s\t%s\n' "$source_max_date" "$target_trade_date"
+}
+
+publication_mode() {
+    local tag release status freshness source_max_date target_trade_date
+    tag="$(TZ=Asia/Shanghai date +%F)" || return 1
+    canonical_date "$tag" || { die "release tag is invalid"; return 1; }
+
+    status=0
+    release="$(github_get_release_by_tag_optional "$tag")" || status=$?
+    if ((status == 0)); then
+        release_identity_is_valid "$release" "$tag" \
+            || { die "release identity, draft, prerelease, or asset shape is invalid"; return 1; }
+        if release_is_complete "$release"; then
+            printf 'Existing release %s has two uploaded canonical assets; validating bytes.\n' \
+                "$tag" >&2
+            printf 'validate-existing\n'
+            return 0
+        fi
+        printf 'Release %s is incomplete; checking whether publication can resume.\n' \
+            "$tag" >&2
+    elif ((status != 4)); then
+        return 1
+    fi
+
+    freshness="$(query_freshness "$tag")" || return 1
+    IFS=$'\t' read -r source_max_date target_trade_date <<<"$freshness"
+    if [[ "$source_max_date" == "$target_trade_date" ]]; then
+        printf 'DoltHub is fresh at %s; publication may proceed.\n' \
+            "$target_trade_date" >&2
+        printf 'publish\n'
+    elif [[ "$source_max_date" < "$target_trade_date" ]]; then
+        printf 'DoltHub source date %s has not reached target trade date %s; skipping this opportunity.\n' \
+            "$source_max_date" "$target_trade_date" >&2
+        printf 'skip\n'
+    else
+        die "source max date $source_max_date is later than target trade date $target_trade_date"
+        return 1
+    fi
+}
+
+main() {
+    if (($# != 0)); then
+        usage
+        return 2
+    fi
+    preflight || return 1
+    publication_mode
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/tests/test_release_safety.py
+++ b/tests/test_release_safety.py
@@ -617,6 +617,7 @@ class StaticSafetyContractTest(unittest.TestCase):
     def test_shell_python_and_yaml_syntax(self):
         shells = [
             "dump_qlib_bin.sh",
+            "release_gate.sh",
             "upload_release.sh",
             "daily_update.sh",
             "ops/investment-data-project-monitor/collect_health.sh",
@@ -681,10 +682,24 @@ class StaticSafetyContractTest(unittest.TestCase):
             operation["options"],
             ["publish", "validate", "repair-2026-07-20"],
         )
+        self.assertEqual(
+            document["on"]["schedule"],
+            [
+                {"cron": "47 10 * * *"},
+                {"cron": "17 11,12 * * *"},
+            ],
+        )
 
     def test_dump_and_uploader_public_grammars_fail_before_work(self):
         dump = subprocess.run(["bash", str(ROOT / "dump_qlib_bin.sh"), "a", "b", "c"], text=True, capture_output=True)
         self.assertEqual(dump.returncode, 2)
+        gate = subprocess.run(
+            ["bash", str(ROOT / "release_gate.sh"), "other"],
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(gate.returncode, 2)
+        self.assertEqual(gate.stdout, "")
         publisher = subprocess.run(["bash", str(ROOT / "upload_release.sh"), "other"], text=True, capture_output=True)
         self.assertEqual(publisher.returncode, 2)
         self.assertEqual(publisher.stdout, "")
@@ -794,6 +809,149 @@ class StaticSafetyContractTest(unittest.TestCase):
                 self.assertEqual(result.stderr, f"Error: {expected_error}\n")
                 self.assertFalse(side_effect_called)
                 self.assertFalse(lock_created)
+
+    def test_release_gate_selects_validate_skip_and_publish_without_mutation(self):
+        complete_release = json.dumps(
+            {
+                "id": 42,
+                "tag_name": "2026-07-20",
+                "draft": False,
+                "prerelease": False,
+                "assets": [
+                    {
+                        "name": "qlib_bin.tar.gz",
+                        "state": "uploaded",
+                        "size": 10,
+                        "digest": "sha256:" + "a" * 64,
+                    },
+                    {
+                        "name": "qlib_bin.manifest.json",
+                        "state": "uploaded",
+                        "size": 10,
+                        "digest": "sha256:" + "b" * 64,
+                    },
+                ],
+            },
+            separators=(",", ":"),
+        )
+        incomplete_release = json.dumps(
+            {
+                "id": 42,
+                "tag_name": "2026-07-20",
+                "draft": False,
+                "prerelease": False,
+                "assets": [
+                    {
+                        "name": "qlib_bin.tar.gz",
+                        "state": "uploaded",
+                        "size": 10,
+                        "digest": "sha256:" + "a" * 64,
+                    }
+                ],
+            },
+            separators=(",", ":"),
+        )
+        cases = (
+            ("complete", complete_release, 0, "", "validate-existing"),
+            ("missing-stale", "", 4, "2026-07-17\t2026-07-20", "skip"),
+            (
+                "incomplete-fresh",
+                incomplete_release,
+                0,
+                "2026-07-20\t2026-07-20",
+                "publish",
+            ),
+        )
+        for label, release, release_status, freshness, expected in cases:
+            with self.subTest(label=label):
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    release_file = root / "release.json"
+                    release_file.write_text(release, encoding="utf-8")
+                    freshness_file = root / "freshness.tsv"
+                    freshness_file.write_text(freshness, encoding="utf-8")
+                    sentinel = root / "freshness-called"
+                    body = r'''
+                      RELEASE_FILE=$1; RELEASE_STATUS=$2; FRESHNESS_FILE=$3
+                      FRESHNESS_SENTINEL=$4
+                      date() {
+                        if [[ "$*" == "+%F" ]]; then
+                          printf '%s\n' 2026-07-20
+                        else
+                          command date "$@"
+                        fi
+                      }
+                      github_get_release_by_tag_optional() {
+                        if [[ "$RELEASE_STATUS" == 0 ]]; then
+                          cat "$RELEASE_FILE"
+                        else
+                          return "$RELEASE_STATUS"
+                        fi
+                      }
+                      query_freshness() {
+                        : >"$FRESHNESS_SENTINEL"
+                        cat "$FRESHNESS_FILE"
+                      }
+                      publication_mode
+                    '''
+                    result = subprocess.run(
+                        [
+                            "bash",
+                            "-c",
+                            'source "$1"; shift; ' + body,
+                            "bash",
+                            str(ROOT / "release_gate.sh"),
+                            str(release_file),
+                            str(release_status),
+                            str(freshness_file),
+                            str(sentinel),
+                        ],
+                        text=True,
+                        capture_output=True,
+                    )
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(result.stdout, expected + "\n")
+                    self.assertEqual(sentinel.exists(), expected != "validate-existing")
+
+    def test_release_gate_rejects_future_source_and_malformed_complete_release(self):
+        bodies = (
+            r'''
+              date() {
+                [[ "$*" == "+%F" ]] && { printf '%s\n' 2026-07-20; return; }
+                command date "$@"
+              }
+              github_get_release_by_tag_optional() { return 4; }
+              query_freshness() { printf '%s\t%s\n' 2026-07-21 2026-07-20; }
+              publication_mode
+            ''',
+            r'''
+              date() {
+                [[ "$*" == "+%F" ]] && { printf '%s\n' 2026-07-20; return; }
+                command date "$@"
+              }
+              github_get_release_by_tag_optional() {
+                printf '%s\n' \
+                  '{"id":42,"tag_name":"2026-07-20","draft":true,"prerelease":false,"assets":[]}'
+              }
+              query_freshness() { exit 99; }
+              publication_mode
+            ''',
+        )
+        for body in bodies:
+            with self.subTest(body=body):
+                result = subprocess.run(
+                    [
+                        "bash",
+                        "-c",
+                        'source "$1"; shift; ' + body,
+                        "bash",
+                        str(ROOT / "release_gate.sh"),
+                    ],
+                    text=True,
+                    capture_output=True,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, "")
 
     def test_forbidden_publisher_environment_is_rejected_before_network_even_when_empty(self):
         forbidden = (
@@ -1533,11 +1691,11 @@ class PublisherStateSimulationTest(unittest.TestCase):
             }
           fi
 
-          if [[ "$OPERATION" == publish ]]; then
-            publish_current
-          else
-            repair_fixed_release
-          fi
+          case "$OPERATION" in
+            publish) publish_current ;;
+            validate-existing) validate_existing_release ;;
+            repair) repair_fixed_release ;;
+          esac
         '''
         return subprocess.run(
             [
@@ -2207,6 +2365,39 @@ class PublisherStateSimulationTest(unittest.TestCase):
                 run_validator(canonical_archive, canonical_manifest, "--require-publishable").returncode,
                 0,
             )
+
+    def test_complete_normal_release_is_validated_without_dolt_or_rebuild(self):
+        pair_root = self.root / "existing-pair"
+        pair_root.mkdir()
+        archive, manifest = build_pair(pair_root)
+        original = self.root / "existing-unused-original"
+        original.write_bytes(b"unused")
+        self.reset_stateful_publish()
+        published = self.run_stateful_publisher(
+            "publish", archive, manifest, original
+        )
+        self.assertEqual(published.returncode, 0, published.stderr)
+        (self.root / "events.log").unlink()
+
+        validated = self.run_stateful_publisher(
+            "validate-existing", archive, manifest, original
+        )
+        self.assertEqual(validated.returncode, 0, validated.stderr)
+        self.assertEqual(
+            validated.stdout,
+            "Validated existing release 2026-07-20 with immutable archive and manifest assets.\n",
+        )
+        events = (self.root / "events.log").read_text().splitlines()
+        self.assertIn("release:get-normal", events)
+        self.assertNotIn("select-dolt", events)
+        self.assertFalse(
+            any(event.startswith(("upload:", "delete:")) for event in events),
+            events,
+        )
+        self.assertEqual(
+            [event for event in events if event.startswith("validate:")],
+            ["validate:existing-archive:existing-manifest"],
+        )
 
     def test_normal_publication_idempotence_archive_only_resume_and_conflicts(self):
         pair_root = self.root / "normal-states-pair"

--- a/tests/test_release_safety.py
+++ b/tests/test_release_safety.py
@@ -657,6 +657,8 @@ class StaticSafetyContractTest(unittest.TestCase):
         self.assertNotIn("svenstaro/upload-release-action", upload)
         self.assertIn("permissions:\n      contents: write", upload)
         self.assertIn("GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}", upload)
+        self.assertIn("uses: actions/checkout@v5", upload)
+        self.assertNotIn("uses: actions/checkout@v4", upload)
         self.assertIn('"chenditc/investment_data@${PUBLICATION_IMAGE_DIGEST}"', upload)
         self.assertNotIn("chenditc/investment_data:latest", upload)
         self.assertIn("sha-${{ github.sha }}", image)

--- a/upload_release.sh
+++ b/upload_release.sh
@@ -29,7 +29,7 @@ die() {
 }
 
 usage() {
-    printf 'usage: %s [repair-2026-07-20]\n' "${0##*/}" >&2
+    printf 'usage: %s [validate-existing|repair-2026-07-20]\n' "${0##*/}" >&2
 }
 
 sha256_file() {
@@ -385,16 +385,8 @@ preflight() {
     ORIGIN_AUTHORITY_VERIFIED=true
 }
 
-get_or_create_release() {
-    local tag=$1 release
-    if release="$(github_get_release_by_tag_optional "$tag")"; then
-        :
-    elif (($? == 4)); then
-        release="$(github_create_release "$tag")" || return 1
-    else
-        die "unable to resolve release $tag"
-        return 1
-    fi
+set_release_identity() {
+    local tag=$1 release=$2
     jq -e --arg tag "$tag" '
         (.id | type) == "number"
         and .id > 0
@@ -404,6 +396,57 @@ get_or_create_release() {
     ' >/dev/null 2>&1 <<<"$release" \
         || { die "release identity, draft, or prerelease state is invalid"; return 1; }
     RELEASE_ID="$(jq -r '.id' <<<"$release")" || return 1
+}
+
+get_existing_release() {
+    local tag=$1 release status=0
+    release="$(github_get_release_by_tag_optional "$tag")" || status=$?
+    if ((status == 4)); then
+        die "release $tag does not exist"
+        return 1
+    elif ((status != 0)); then
+        die "unable to resolve release $tag"
+        return 1
+    fi
+    set_release_identity "$tag" "$release"
+}
+
+get_or_create_release() {
+    local tag=$1 release status=0
+    release="$(github_get_release_by_tag_optional "$tag")" || status=$?
+    if ((status == 4)); then
+        release="$(github_create_release "$tag")" || return 1
+    elif ((status != 0)); then
+        die "unable to resolve release $tag"
+        return 1
+    fi
+    set_release_identity "$tag" "$release"
+}
+
+validate_existing_release() {
+    local tag assets archive_slot manifest_slot archive_state manifest_state
+    local downloaded_archive downloaded_manifest
+    tag="$(TZ=Asia/Shanghai date +%F)" || return 1
+    get_existing_release "$tag" || return 1
+    assets="$(list_assets)" || return 1
+    [[ "$(jq 'length' <<<"$assets")" == "2" ]] \
+        || { die "existing release must contain exactly two assets"; return 1; }
+    archive_slot="$(slot_json "$assets" "$ARCHIVE_NAME")" || return 1
+    manifest_slot="$(slot_json "$assets" "$MANIFEST_NAME")" || return 1
+    archive_state="$(slot_state "$archive_slot")" || return 1
+    manifest_state="$(slot_state "$manifest_slot")" || return 1
+    [[ "$archive_state" == "uploaded" && "$manifest_state" == "uploaded" ]] \
+        || { die "existing release canonical assets are incomplete"; return 1; }
+
+    downloaded_archive="$WORK_DIR/existing-archive"
+    downloaded_manifest="$WORK_DIR/existing-manifest"
+    redownload_named_asset "$ARCHIVE_NAME" "$downloaded_archive" >/dev/null \
+        || return 1
+    redownload_named_asset "$MANIFEST_NAME" "$downloaded_manifest" >/dev/null \
+        || return 1
+    validate_pair "$downloaded_archive" "$downloaded_manifest" "$tag" || return 1
+    printf 'Validated existing release %s with immutable archive and manifest assets.\n' \
+        "$tag"
 }
 
 publish_current() {
@@ -1133,7 +1176,8 @@ main() {
     local operation
     if (($# == 0)); then
         operation=publish
-    elif (($# == 1)) && [[ "$1" == "repair-2026-07-20" ]]; then
+    elif (($# == 1)) \
+        && [[ "$1" == "validate-existing" || "$1" == "repair-2026-07-20" ]]; then
         operation=$1
     else
         usage
@@ -1143,11 +1187,11 @@ main() {
     preflight "$operation" || return 1
     WORK_DIR="$(mktemp -d /tmp/investment-data-publisher.XXXXXXXX)" || return 1
     trap 'status=$?; [[ -z "$WORK_DIR" || ! -d "$WORK_DIR" ]] || rm -rf -- "$WORK_DIR"; exit "$status"' EXIT
-    if [[ "$operation" == "publish" ]]; then
-        publish_current
-    else
-        repair_fixed_release
-    fi
+    case "$operation" in
+        publish) publish_current ;;
+        validate-existing) validate_existing_release ;;
+        repair-2026-07-20) repair_fixed_release ;;
+    esac
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then


### PR DESCRIPTION
## Summary
- replace the single 19:01 cron with staggered 18:47, 19:17, and 20:17 opportunities
- gate scheduled publication on current DoltHub freshness and skip cleanly when data is not ready
- detect a complete daily release before restoring the large Dolt snapshot
- re-download and semantically validate the existing canonical archive/manifest pair without rebuilding or mutating release assets

## Correctness and safety
- existing source-date == target-trading-date check remains in the full builder
- shared workflow concurrency still serializes update and release jobs
- incomplete releases only enter the existing fail-safe resume path
- complete releases require exactly two uploaded canonical assets with GitHub SHA-256 metadata, then byte and archive validation

## Local validation
- 15 qlib unit tests passed
- 28 focused release safety, gate, publisher state-machine, and archive-validator tests passed
- live read-only gate check for 2026-07-27 selected `publish` because DoltHub source and target were both 2026-07-27 and the release was missing
- `bash -n` and `git diff --check` passed