### PR TITLE
Avoid release validation monitor race

### DIFF
--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -194,24 +194,29 @@ jobs:
             "${container_command[@]}" &
           run_pid=$!
 
-          (
-            while kill -0 "$run_pid" 2>/dev/null; do
-              date -u
-              docker stats --no-stream \
-                --format 'memory={{.MemUsage}} cpu={{.CPUPerc}} block={{.BlockIO}}' \
-                upload_tar || true
-              df -h "$RUNNER_TEMP"
-              sleep 30
-            done
-          ) &
-          monitor_pid=$!
+          monitor_pid=""
+          if [[ "${{ steps.publication-gate.outputs.mode }}" != "validate-existing" ]]; then
+            (
+              while kill -0 "$run_pid" 2>/dev/null; do
+                date -u
+                docker stats --no-stream \
+                  --format 'memory={{.MemUsage}} cpu={{.CPUPerc}} block={{.BlockIO}}' \
+                  upload_tar || true
+                df -h "$RUNNER_TEMP"
+                sleep 30
+              done
+            ) &
+            monitor_pid=$!
+          fi
 
           set +e
           wait "$run_pid"
           status=$?
           set -e
-          kill "$monitor_pid" >/dev/null 2>&1 || true
-          wait "$monitor_pid" >/dev/null 2>&1 || true
+          if [[ -n "$monitor_pid" ]]; then
+            kill "$monitor_pid" >/dev/null 2>&1 || true
+            wait "$monitor_pid" >/dev/null 2>&1 || true
+          fi
           exit "$status"
 
       - name: Verify the build snapshot

--- a/tests/test_release_safety.py
+++ b/tests/test_release_safety.py
@@ -659,6 +659,10 @@ class StaticSafetyContractTest(unittest.TestCase):
         self.assertIn("GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}", upload)
         self.assertIn("uses: actions/checkout@v5", upload)
         self.assertNotIn("uses: actions/checkout@v4", upload)
+        self.assertIn(
+            'if [[ "${{ steps.publication-gate.outputs.mode }}" != "validate-existing" ]]',
+            upload,
+        )
         self.assertIn('"chenditc/investment_data@${PUBLICATION_IMAGE_DIGEST}"', upload)
         self.assertNotIn("chenditc/investment_data:latest", upload)
         self.assertIn("sha-${{ github.sha }}", image)


### PR DESCRIPTION
Follow-up to #154. The new validate-existing path can finish before the background Docker stats sample starts, producing a misleading non-fatal `No such container` line. Skip the resource monitor for the read-only existing-release validation path; actual build/publish modes remain monitored.\n\nValidated with actionlint and focused workflow safety tests.